### PR TITLE
[Feat] #21 - 이용 내역, 등록 내역 페이지 화면 구현

### DIFF
--- a/TeamProject/KakaoAPIKey.xcconfig
+++ b/TeamProject/KakaoAPIKey.xcconfig
@@ -7,4 +7,4 @@
 
 // Configuration settings file format documentation can be found at:
 // https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
-KAKAO_API_KEY = d6b052fb04b20a9be1fbb390a64bff21
+KAKAO_API_KEY = 

--- a/TeamProject/KakaoAPIKey.xcconfig
+++ b/TeamProject/KakaoAPIKey.xcconfig
@@ -7,4 +7,4 @@
 
 // Configuration settings file format documentation can be found at:
 // https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
-KAKAO_API_KEY =
+KAKAO_API_KEY = d6b052fb04b20a9be1fbb390a64bff21

--- a/TeamProject/TeamProject/App/SceneDelegate.swift
+++ b/TeamProject/TeamProject/App/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let vc = MainViewController()
+        let vc = LoginViewController()
         let navigationController = UINavigationController(rootViewController: vc)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()

--- a/TeamProject/TeamProject/MainViewController.swift
+++ b/TeamProject/TeamProject/MainViewController.swift
@@ -44,10 +44,8 @@ final class MainViewController: UITabBarController {
     private func setAttribute() {
         viewControllers = [
             createViewController(for: RentViewController(), title: "대여"),
-
             createViewController(for: KickBoardRegisterViewController(), title: "킥보드 등록"),
-
-            createViewController(for: MyPageViewController(), title: "마이페이지")
+            createNavigationController(for: MyPageViewController(), title: "마이페이지")
 
         ]
     }
@@ -59,7 +57,6 @@ final class MainViewController: UITabBarController {
     }
     
     // Navigation이 포함된 UIViewController 생성
-
     private func createNavigationController(for vc: UIViewController, title: String?) -> UIViewController {
         let navigationController = UINavigationController(rootViewController: vc)
         navigationController.navigationBar.isTranslucent = false

--- a/TeamProject/TeamProject/Utility/Literals/FontLiterals.swift
+++ b/TeamProject/TeamProject/Utility/Literals/FontLiterals.swift
@@ -105,13 +105,13 @@ extension FontLiterals {
 
         case .UsageHistoryKickboardID: return 15
         case .UsageHistoryDate: return 13
-        case .UsageHistoryUseTime, .UsageHistoryDistance: return 10
+        case .UsageHistoryUseTime, .UsageHistoryDistance: return 11
         case .UsageHistoryCharge: return 14
 
         case .RegistrationHistoryKickboardID: return 15
         case .RegistrationHistoryDate: return 13
         case .RegistrationHistoryBasicCharge,
-             .RegistrationHistoryHourlyCharge: return 10
+             .RegistrationHistoryHourlyCharge: return 11
             
         case .TabBarTitle: return 17
         }

--- a/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
+++ b/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class LoginViewController: UIViewController {
+final class LoginViewController: UIViewController,LoginViewContollerProtocol {
     
     // MARK: - UI Components
     
@@ -27,12 +27,6 @@ final class LoginViewController: UIViewController {
     }
     
     // MARK: - Methods
-    
-    /// 화면 전환을 위한 델리게이트 설정
-    private func loginViewDelegate() {
-        loginView.delegate = self
-    }
-    
     /// loginView의 화면 제약
     private func setupLoginView() {
         view.addSubview(loginView)
@@ -42,6 +36,22 @@ final class LoginViewController: UIViewController {
     /// memebershipView의 네비게이션 뒤로가기 타이틀 없애기
     private func setupNavigationBar() {
         navigationItem.backButtonTitle = ""
+    }
+    
+    /// 화면 전환을 위한 델리게이트 설정
+    private func loginViewDelegate() {
+        loginView.delegate = self
+    }
+    
+    func loginButtonTapped() {
+        let mainVC = MainViewController()
+        mainVC.modalPresentationStyle = .fullScreen
+        present(mainVC, animated: true, completion: nil)
+    }
+    
+    func signUpButtonTapped() {
+        let membershipVC = MembershipViewController()
+        navigationController?.pushViewController(membershipVC, animated: true)
     }
     
     // MARK: - @objc Methods
@@ -56,20 +66,5 @@ final class LoginViewController: UIViewController {
     /// 키보드 확장 옵저버 종료
     deinit {
         removeKeyboardObserver()
-    }
-}
-
-// MARK: - ExchangeViewProtoocol
-
-extension LoginViewController: LoginViewContollerProtocol {
-    func loginButtonTapped() {
-        let mainVC = MainViewController()
-        mainVC.modalPresentationStyle = .fullScreen
-        present(mainVC, animated: true, completion: nil)
-    }
-    
-    func signUpButtonTapped() {
-        let membershipVC = MembershipViewController()
-        navigationController?.pushViewController(membershipVC, animated: true)
     }
 }

--- a/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
+++ b/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
@@ -27,6 +27,7 @@ final class LoginViewController: UIViewController,LoginViewContollerProtocol {
     }
     
     // MARK: - Methods
+    
     /// loginView의 화면 제약
     private func setupLoginView() {
         view.addSubview(loginView)

--- a/TeamProject/TeamProject/View/LoginView/ViewComponents/LoginView.swift
+++ b/TeamProject/TeamProject/View/LoginView/ViewComponents/LoginView.swift
@@ -16,6 +16,8 @@ final class LoginView: UIView, UITextFieldDelegate {
     
     weak var delegate: LoginViewContollerProtocol?
     
+    // MARK: 
+    
     private let loginPageTitle = UILabel().then {
         $0.text = "안녕하세요.\nGodRide입니다."
         $0.textColor = .label

--- a/TeamProject/TeamProject/View/MembershipView/MembershipViewController.swift
+++ b/TeamProject/TeamProject/View/MembershipView/MembershipViewController.swift
@@ -12,8 +12,8 @@ import Then
 
 class MembershipViewController: UIViewController {
     
-    // MARK: - UI Components
-    
+    // MARK: - Properties
+
     private var membershipView = MembershipView()
     
     // MARK: - View Life Cycle

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageTableViewCell.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageTableViewCell.swift
@@ -14,13 +14,14 @@ final class MyPageTableViewCell: UITableViewCell {
     
     // MARK: - Properties
     static let id = "TableViewCell"
+    weak var delegate: MyPageTableViewCellProtocol?
     
     static let data: [(title: String, details: [String])] = [
         ("이용 내역", ["전체 이용 내역 보기"]),
         ("등록한 킥보드", ["전체 등록 내역 보기"]),
         ("고객센터", ["자주 묻는 질문", "1:1 문의하기", "공지사항"])
     ]
-
+    
     // MARK: - UI Components
     private let titleLabel = UILabel().then {
         $0.font = UIFont.fontGuide(.MyPageRegistrationKickboardLabel)
@@ -33,29 +34,22 @@ final class MyPageTableViewCell: UITableViewCell {
         $0.alignment = .leading
         $0.distribution = .fillProportionally
     }
-
-    private let arrowButton = UIButton().then {
-        $0.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        $0.setTitleColor(.systemBackground, for: .normal)
-        $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
-    }
-
+    
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
         selectionStyle = .none
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     // MARK: - Layout Helper
     private func setup() {
         contentView.addSubview(titleLabel)
         contentView.addSubview(stackView)
-        contentView.addSubview(arrowButton)
         
         titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(20)
@@ -64,14 +58,8 @@ final class MyPageTableViewCell: UITableViewCell {
         
         stackView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(20)
-            make.leading.equalToSuperview()
-            make.trailing.equalTo(arrowButton.snp.leading)
+            make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview().offset(-10)
-        }
-        
-        arrowButton.snp.makeConstraints { make in
-            make.centerY.equalTo(stackView)
-            make.trailing.equalToSuperview()
         }
     }
     
@@ -79,15 +67,52 @@ final class MyPageTableViewCell: UITableViewCell {
     func configure(with title: String, details: [String]) {
         titleLabel.text = title
         
-        /// 스택뷰 초기화
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         details.forEach { detailText in
+            let containerView = UIView()
             let label = UILabel()
             label.text = detailText
             label.font = UIFont.fontGuide(.MyPageTotalRegistrationKickboardLabel)
             label.textColor = .label
-            stackView.addArrangedSubview(label)
+            
+            if ["자주 묻는 질문", "1:1 문의하기", "공지사항"].contains(detailText) {
+                stackView.addArrangedSubview(label)
+            } else {
+                let arrowButton = UIButton().then {
+                    $0.tintColor = .systemGray
+                    $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+                    $0.accessibilityLabel = detailText
+                    $0.addTarget(self, action: #selector(arrowButtonTapped(_:)), for: .touchUpInside)
+                }
+                
+                containerView.addSubview(label)
+                containerView.addSubview(arrowButton)
+                
+                label.snp.makeConstraints { make in
+                    make.leading.centerY.equalToSuperview()
+                }
+                
+                arrowButton.snp.makeConstraints { make in
+                    make.trailing.centerY.equalToSuperview()
+                    make.leading.greaterThanOrEqualTo(label.snp.trailing).offset(8) // 동적인 텍스트 길이에 대응
+                }
+                
+                stackView.addArrangedSubview(containerView)
+                containerView.snp.makeConstraints { make in
+                    make.width.equalToSuperview()
+                    make.height.equalTo(30) // 컨테이너 높이 고정
+                }
+            }
+        }
+    }
+    
+    @objc private func arrowButtonTapped(_ sender: UIButton) {
+        guard let text = sender.accessibilityLabel else { return }
+        if text == "전체 이용 내역 보기" {
+            delegate?.usageHistoryButtonTapped()
+        } else if text == "전체 등록 내역 보기" {
+            delegate?.registrationHistoryButtonTapped()
         }
     }
 }

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageTableViewCell.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageTableViewCell.swift
@@ -13,6 +13,7 @@ import Then
 final class MyPageTableViewCell: UITableViewCell {
     
     // MARK: - Properties
+    
     static let id = "TableViewCell"
     weak var delegate: MyPageTableViewCellProtocol?
     
@@ -23,6 +24,7 @@ final class MyPageTableViewCell: UITableViewCell {
     ]
     
     // MARK: - UI Components
+    
     private let titleLabel = UILabel().then {
         $0.font = UIFont.fontGuide(.MyPageRegistrationKickboardLabel)
         $0.textColor = .secondaryLabel
@@ -36,6 +38,7 @@ final class MyPageTableViewCell: UITableViewCell {
     }
     
     // MARK: - Initializer
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
@@ -47,6 +50,7 @@ final class MyPageTableViewCell: UITableViewCell {
     }
     
     // MARK: - Layout Helper
+    
     private func setup() {
         contentView.addSubview(titleLabel)
         contentView.addSubview(stackView)
@@ -64,6 +68,7 @@ final class MyPageTableViewCell: UITableViewCell {
     }
     
     // MARK: - Methods
+    
     func configure(with title: String, details: [String]) {
         titleLabel.text = title
         
@@ -106,6 +111,8 @@ final class MyPageTableViewCell: UITableViewCell {
             }
         }
     }
+    
+    // MARK: - @objc Methods
     
     @objc private func arrowButtonTapped(_ sender: UIButton) {
         guard let text = sender.accessibilityLabel else { return }

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageView.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageView.swift
@@ -15,6 +15,7 @@ final class MyPageView: UIView, UITableViewDataSource, UITableViewDelegate {
     // MARK: - Properties
     static let id = "TableViewCell"
     weak var delegate: LogoutViewControllerProtocol?
+    weak var cellDelegate: MyPageTableViewCellProtocol?  // 추가
     
     // MARK: - UI Components
     private let userNameLabel = UILabel().then {
@@ -32,7 +33,7 @@ final class MyPageView: UIView, UITableViewDataSource, UITableViewDelegate {
         $0.tintColor = .white
     }
     
-    private let tableView = UITableView().then {
+    let tableView = UITableView().then {
         $0.separatorStyle = .singleLine
         $0.register(MyPageTableViewCell.self, forCellReuseIdentifier: MyPageTableViewCell.id)
         $0.isScrollEnabled = false
@@ -125,6 +126,7 @@ final class MyPageView: UIView, UITableViewDataSource, UITableViewDelegate {
         let titleText = MyPageTableViewCell.data[indexPath.section].title
         let detailTexts = MyPageTableViewCell.data[indexPath.section].details
         cell.configure(with: titleText, details: detailTexts)
+        cell.delegate = cellDelegate  // cellDelegate 설정
         return cell
     }
     

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageView.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewComponenets/MyPageView.swift
@@ -13,11 +13,12 @@ import Then
 final class MyPageView: UIView, UITableViewDataSource, UITableViewDelegate {
     
     // MARK: - Properties
-    static let id = "TableViewCell"
+    
     weak var delegate: LogoutViewControllerProtocol?
     weak var cellDelegate: MyPageTableViewCellProtocol?  // 추가
     
     // MARK: - UI Components
+    
     private let userNameLabel = UILabel().then {
         $0.text = "Test님"
         $0.font = UIFont.fontGuide(.MyPageUserName)

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewController.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class MyPageViewController: UIViewController, LogoutViewControllerProtocol, MyPageTableViewCellProtocol {
     
-    // MARK: - UI Components
+    // MARK: - Properties
     private var mypageView = MyPageView()
     private var mypageTableViewCell = MyPageTableViewCell()
     

--- a/TeamProject/TeamProject/View/MyPageView/MyPageViewController.swift
+++ b/TeamProject/TeamProject/View/MyPageView/MyPageViewController.swift
@@ -9,29 +9,37 @@ import UIKit
 
 import SnapKit
 
-final class MyPageViewController: UIViewController, LogoutViewControllerProtocol {
+final class MyPageViewController: UIViewController, LogoutViewControllerProtocol, MyPageTableViewCellProtocol {
     
     // MARK: - UI Components
     private var mypageView = MyPageView()
+    private var mypageTableViewCell = MyPageTableViewCell()
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupUI()
-        logoutViewDelegate()
+        setupMyPageView()
+        setupDelegates()
+        setupNavigationBar()
     }
     
     // MARK: - Layout Helper
-    private func setupUI() {
+    private func setupMyPageView() {
         view.addSubviews(mypageView)
         mypageView.snp.makeConstraints { $0.edges.equalToSuperview()
         }
     }
     
+    /// 네비게이션 뒤로가기 타이틀 없애기
+    private func setupNavigationBar() {
+        navigationItem.backButtonTitle = ""
+    }
+    
     // MARK: - Methods
     /// 화면 전환을 위한 델리게이트 설정
-    private func logoutViewDelegate() {
+    private func setupDelegates() {
         mypageView.delegate = self
+        mypageView.cellDelegate = self  // cellDelegate 설정
     }
     
     // MARK: - Actions
@@ -39,5 +47,15 @@ final class MyPageViewController: UIViewController, LogoutViewControllerProtocol
         let loginVC = LoginViewController()
         loginVC.modalPresentationStyle = .fullScreen
         present(loginVC, animated: true, completion: nil)
+    }
+    
+    func usageHistoryButtonTapped() {
+        let usageHistoryVC = UsageHistoryViewController()
+        navigationController?.pushViewController(usageHistoryVC, animated: true)
+    }
+    
+    func registrationHistoryButtonTapped() {
+        let registrationHistoryVC = RegistrationHistoryViewController()
+        navigationController?.pushViewController(registrationHistoryVC, animated: true)
     }
 }

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistory.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistory.swift
@@ -1,0 +1,50 @@
+//
+//  RegistrationHistory.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import Foundation
+
+struct RegistrationHistory {
+    let kickboardId: String
+    let basicFee: Int
+    let hourlyFee: Int
+    let date: String
+    
+    // 편의를 위한 초기화 메서드
+    init(kickboardId: String, basicFee: Int, hourlyFee: Int, date: String) {
+        self.kickboardId = kickboardId
+        self.basicFee = basicFee
+        self.hourlyFee = hourlyFee
+        self.date = date
+    }
+}
+
+extension RegistrationHistory {
+    // 기본 이용료 포맷팅
+    var formattedBasicFee: String {
+        return "\(basicFee.formatted())원"
+    }
+    
+    // 시간당 요금 포맷팅
+    var formattedHourlyFee: String {
+        return "\(hourlyFee.formatted())원"
+    }
+    
+    // 날짜 포맷팅 (필요한 경우)
+    var formattedDate: String {
+        return date
+    }
+    
+    // 전체 정보 요약
+    var summary: String {
+        return """
+        킥보드 ID: \(kickboardId)
+        기본 이용료: \(formattedBasicFee)
+        시간당 요금: \(formattedHourlyFee)
+        등록일: \(formattedDate)
+        """
+    }
+}

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistory.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistory.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// MARK: Properties
+
 struct RegistrationHistory {
     let kickboardId: String
     let basicFee: Int
@@ -21,6 +23,8 @@ struct RegistrationHistory {
         self.date = date
     }
 }
+
+// MARK: - RegistrationHistory Extensions
 
 extension RegistrationHistory {
     // 기본 이용료 포맷팅

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -11,11 +11,12 @@ import SnapKit
 import Then
 
 final class RegistrationHistoryTableViewCell: UITableViewCell {
+    
     // MARK: - Properties
     
     static let RegistrationHistoryCellid = "registrationHistoryCell"
     
-    // MARK: UI Components
+    // MARK: - UI Components
     
     private let containerStackView = UIStackView().then {
         $0.axis = .horizontal
@@ -36,27 +37,27 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
     }
     
     private let kickboardIdLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 16, weight: .medium)
-        $0.textColor = .black
+        $0.font = UIFont.fontGuide(.UsageHistoryKickboardID)
+        $0.textColor = .label
     }
     
     private let basicFeeLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 13)
-        $0.textColor = .darkGray
+        $0.font = UIFont.fontGuide(.RegistrationHistoryBasicCharge)
+        $0.textColor = .secondaryLabel
     }
     
     private let hourlyFeeLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 13)
-        $0.textColor = .darkGray
+        $0.font = UIFont.fontGuide(.RegistrationHistoryHourlyCharge)
+        $0.textColor = .secondaryLabel
     }
     
     private let dateLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 14)
-        $0.textColor = .black
+        $0.font = UIFont.fontGuide(.RegistrationHistoryDate)
+        $0.textColor = .label
         $0.textAlignment = .right
     }
     
-    // MARK: - Init
+    // MARK: - Initializer
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -90,6 +91,11 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
     }
     
     private func setConstraints() {
+        contentView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(370)
+            make.height.equalTo(100)
+        }
         kickboardImageView.snp.makeConstraints { make in
             make.width.height.equalTo(40)
         }
@@ -103,11 +109,6 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
         dateLabel.snp.makeConstraints { make in
             make.trailing.equalToSuperview().offset(-16)
             make.centerY.equalToSuperview()
-        }
-        
-        contentView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16))
-            make.height.equalTo(80)
         }
     }
     

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -11,5 +11,118 @@ import SnapKit
 import Then
 
 final class RegistrationHistoryTableViewCell: UITableViewCell {
+    // MARK: - Properties
     
+    static let RegistrationHistoryCellid = "registrationHistoryCell"
+    
+    // MARK: UI Components
+    
+    private let containerStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 15
+        $0.alignment = .center
+    }
+    
+    private let kickboardImageView = UIImageView().then {
+        $0.image = ImageLiterals.kickboard
+        $0.contentMode = .scaleAspectFit
+        $0.clipsToBounds = true
+    }
+    
+    private let infoStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 5
+        $0.alignment = .leading
+    }
+    
+    private let kickboardIdLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16, weight: .medium)
+        $0.textColor = .black
+    }
+    
+    private let basicFeeLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 13)
+        $0.textColor = .darkGray
+    }
+    
+    private let hourlyFeeLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 13)
+        $0.textColor = .darkGray
+    }
+    
+    private let dateLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 14)
+        $0.textColor = .black
+        $0.textAlignment = .right
+    }
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+        setConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    
+    private func setup() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .systemGray6
+        contentView.layer.cornerRadius = 12
+        contentView.clipsToBounds = true
+        selectionStyle = .none
+        
+        contentView.addSubview(containerStackView)
+        contentView.addSubview(dateLabel)
+        
+        containerStackView.addArrangedSubview(kickboardImageView)
+        containerStackView.addArrangedSubview(infoStackView)
+        
+        [kickboardIdLabel, basicFeeLabel, hourlyFeeLabel].forEach {
+            infoStackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func setConstraints() {
+        kickboardImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(40)
+        }
+        
+        containerStackView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(16)
+            make.centerY.equalToSuperview()
+            make.trailing.lessThanOrEqualTo(dateLabel.snp.leading).offset(-16)
+        }
+        
+        dateLabel.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-16)
+            make.centerY.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16))
+            make.height.equalTo(80)
+        }
+    }
+    
+    private func configureUI() {
+        // 테스트용 더미 데이터
+        kickboardIdLabel.text = "ABCDEF"
+        basicFeeLabel.text = "기본 이용료: 1,000원"
+        hourlyFeeLabel.text = "시간당 요금: 200원"
+        dateLabel.text = "2025.04.30"
+    }
+    
+    func configure(with model: RegistrationHistory) {
+        kickboardIdLabel.text = model.kickboardId
+        basicFeeLabel.text = "기본 이용료: \(model.basicFee)원"
+        hourlyFeeLabel.text = "시간당 요금: \(model.hourlyFee)원"
+        dateLabel.text = model.date
+    }
 }

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -1,0 +1,15 @@
+//
+//  RegistrationHistoryTableViewCell.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RegistrationHistoryTableViewCell: UITableViewCell {
+    
+}

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
@@ -12,8 +12,6 @@ import Then
 
 final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
     
-    // MARK: - Properties
-    
     // MARK: - UI Components
     
     private lazy var tableView = UITableView().then {
@@ -22,7 +20,7 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
         $0.register(RegistrationHistoryTableViewCell.self, forCellReuseIdentifier: RegistrationHistoryTableViewCell.RegistrationHistoryCellid)
     }
     
-    // MARK: - Init
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,11 +33,11 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
     }
     
     // MARK: - Methods
-
+    
     private func setup() {
         backgroundColor = .systemBackground
         addSubviews(tableView)
-
+        
         tableView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(20)
             make.leading.trailing.equalToSuperview()
@@ -73,7 +71,7 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
     func numberOfSections(in tableView: UITableView) -> Int {
         return 3 // 섹션 3개로 설정
     }
-
+    
     // numberOfRowsInSection 수정
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1 // 각 섹션당 1개의 셀만 표시

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
@@ -10,17 +10,86 @@ import UIKit
 import SnapKit
 import Then
 
-final class RegistrationHistoryView: UIView {
+final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private lazy var tableView = UITableView().then {
+        $0.backgroundColor = .clear
+        $0.separatorStyle = .none
+        $0.register(RegistrationHistoryTableViewCell.self, forCellReuseIdentifier: RegistrationHistoryTableViewCell.RegistrationHistoryCellid)
+    }
+    
+    // MARK: - Init
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        tableViewDelegate()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Methods
+
     private func setup() {
         backgroundColor = .systemBackground
+        addSubviews(tableView)
+
+        tableView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(20)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-20)
+        }
+        
+        tableView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+    }
+    
+    private func tableViewDelegate() {
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+    
+    // 테이블뷰의 각 섹션의 헤더 높이를 설정 (헤더 높이 0으로 설정)
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 0
+    }
+    
+    //푸터에 특별한 내용을 표시하지 않고 단순히 간격을 주기 위한 용도로 사용
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+    
+    // 푸터의 높이를 20포인트로 설정 (셀 간의 간격)
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 20
+    }
+    
+    // numberOfSections 메서드 추가
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 3 // 섹션 3개로 설정
+    }
+
+    // numberOfRowsInSection 수정
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1 // 각 섹션당 1개의 셀만 표시
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: RegistrationHistoryTableViewCell.RegistrationHistoryCellid, for: indexPath) as? RegistrationHistoryTableViewCell else {
+            return UITableViewCell()
+        }
+        // 실제 데이터로 구성할 때 아래와 같이 적으면 됨
+        // cell.configure(with: yourDataModel)
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        100
     }
 }

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
@@ -1,0 +1,26 @@
+//
+//  RegistrationHistoryView.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RegistrationHistoryView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setup() {
+        backgroundColor = .systemBackground
+    }
+}

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
@@ -11,7 +11,8 @@ import SnapKit
 
 final class RegistrationHistoryViewController: UIViewController {
     
-    // MARK: - UI Components
+    // MARK: - Properties
+    
     private var registrationHistoryView = RegistrationHistoryView()
        
     // MARK: - View Life Cycle
@@ -23,7 +24,7 @@ final class RegistrationHistoryViewController: UIViewController {
     }
     
     // MARK: - Methods
-
+    
     private func setupNavigationBar() {
         navigationItem.title = "등록 내역"
     }

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
@@ -1,0 +1,35 @@
+//
+//  RegistrationHistoryViewController.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RegistrationHistoryViewController: UIViewController {
+    
+    // MARK: - UI Components
+    private var registrationHistoryView = RegistrationHistoryView()
+       
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupRegistrationHistoryView()
+        setupNavigationBar()
+    }
+    
+    // MARK: - Methods
+
+    private func setupNavigationBar() {
+        navigationItem.title = "등록 내역"
+    }
+    
+    private func setupRegistrationHistoryView() {
+        view.addSubview(registrationHistoryView)
+        registrationHistoryView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+}

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistory.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistory.swift
@@ -6,6 +6,8 @@
 //
 import Foundation
 
+// MARK: Properties
+
 struct UsageHistory {
     let kickboardId: String
     let usageTime: String
@@ -33,6 +35,7 @@ struct UsageHistory {
 }
 
 // MARK: - UsageHistory Extensions
+
 extension UsageHistory {
     // 사용 시간을 분으로 계산
     var durationInMinutes: Int? {

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistory.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistory.swift
@@ -1,0 +1,81 @@
+//
+//  UsageHistory.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+import Foundation
+
+struct UsageHistory {
+    let kickboardId: String
+    let usageTime: String
+    let distance: Double
+    let date: String
+    let price: Int
+    
+    // 기본 초기화 메서드
+    init(kickboardId: String, usageTime: String, distance: Double, date: String, price: Int) {
+        self.kickboardId = kickboardId
+        self.usageTime = usageTime
+        self.distance = distance
+        self.date = date
+        self.price = price
+    }
+    
+    // 시작 시간과 종료 시간을 받아서 usageTime을 자동으로 생성하는 편의 초기화 메서드
+    init(kickboardId: String, startTime: String, endTime: String, distance: Double, date: String, price: Int) {
+        self.kickboardId = kickboardId
+        self.usageTime = "\(startTime) ~ \(endTime)"
+        self.distance = distance
+        self.date = date
+        self.price = price
+    }
+}
+
+// MARK: - UsageHistory Extensions
+extension UsageHistory {
+    // 사용 시간을 분으로 계산
+    var durationInMinutes: Int? {
+        let components = usageTime.components(separatedBy: " ~ ")
+        guard components.count == 2 else { return nil }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        
+        guard let startTime = formatter.date(from: components[0]),
+              let endTime = formatter.date(from: components[1]) else { return nil }
+        
+        return Calendar.current.dateComponents([.minute], from: startTime, to: endTime).minute
+    }
+    
+    // 포맷된 사용 시간 (30분)
+    var formattedDuration: String {
+        if let minutes = durationInMinutes {
+            return "\(minutes)분"
+        }
+        return "시간 정보 없음"
+    }
+    
+    // 거리 포맷팅
+    var formattedDistance: String {
+        return String(format: "%.1fkm", distance)
+    }
+    
+    // 가격 포맷팅
+    var formattedPrice: String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return "\(numberFormatter.string(from: NSNumber(value: price)) ?? String(price))원"
+    }
+    
+    // 전체 정보 요약
+    var summary: String {
+        return """
+        킥보드 ID: \(kickboardId)
+        이용 시간: \(usageTime) (\(formattedDuration))
+        이동 거리: \(formattedDistance)
+        이용 요금: \(formattedPrice)
+        이용일: \(date)
+        """
+    }
+}

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -16,7 +16,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     
     static let usageHistoryCellid = "UsageHistoryCell"
     
-    // MARK: UI Components
+    // MARK: - UI Components
     
     private let leftContentStackView = UIStackView().then {
         $0.axis = .horizontal
@@ -43,27 +43,27 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     }
     
     private let kickboardIdLabel = UILabel().then {
-        $0.font = .boldSystemFont(ofSize: 15)
+        $0.font = UIFont.fontGuide(.UsageHistoryKickboardID)
         $0.textAlignment = .left
-        $0.textColor = .black
+        $0.textColor = .label
     }
     
     private let usageTimeLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 10)
+        $0.font = UIFont.fontGuide(.UsageHistoryUseTime)
         $0.textAlignment = .left
-        $0.textColor = .black
+        $0.textColor = .secondaryLabel
     }
     
     private let distanceLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 10)
+        $0.font = UIFont.fontGuide(.UsageHistoryDistance)
         $0.textAlignment = .left
-        $0.textColor = .black
+        $0.textColor = .secondaryLabel
     }
     
     private let dateLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 13)
+        $0.font = UIFont.fontGuide(.UsageHistoryDate)
         $0.textAlignment = .right
-        $0.textColor = .black
+        $0.textColor = .label
     }
     
     private let priceLabel = UILabel().then {
@@ -72,7 +72,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
         $0.textColor = UIColor.asset(.main)
     }
     
-    // MARK: - Init
+    // MARK: - Initializer
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -85,7 +85,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Setup
+    // MARK: - Methods
     
     private func setup() {
         backgroundColor = .clear
@@ -117,7 +117,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
             make.leading.equalTo(20)
             make.trailing.equalTo(-20)
         }
-
+        
         kickboardImageView.snp.makeConstraints { make in
             make.width.height.equalTo(50)
         }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -1,0 +1,15 @@
+//
+//  UsageHistoryTableViewCell.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class UsageHistoryTableViewCell: UITableViewCell {
+
+}

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -11,5 +11,142 @@ import SnapKit
 import Then
 
 final class UsageHistoryTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let usageHistoryCellid = "UsageHistoryCell"
+    
+    // MARK: UI Components
+    
+    private let leftContentStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.alignment = .center
+    }
+    
+    private let kickboardImageView = UIImageView().then {
+        $0.image = ImageLiterals.kickboard
+        $0.contentMode = .scaleAspectFit
+        $0.clipsToBounds = true
+    }
+    
+    private let infoStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 3
+        $0.alignment = .leading
+    }
+    
+    private let rightContentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 7
+        $0.alignment = .trailing
+    }
+    
+    private let kickboardIdLabel = UILabel().then {
+        $0.font = .boldSystemFont(ofSize: 15)
+        $0.textAlignment = .left
+        $0.textColor = .black
+    }
+    
+    private let usageTimeLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 10)
+        $0.textAlignment = .left
+        $0.textColor = .black
+    }
+    
+    private let distanceLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 10)
+        $0.textAlignment = .left
+        $0.textColor = .black
+    }
+    
+    private let dateLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 13)
+        $0.textAlignment = .right
+        $0.textColor = .black
+    }
+    
+    private let priceLabel = UILabel().then {
+        $0.font = .boldSystemFont(ofSize: 15)
+        $0.textAlignment = .right
+        $0.textColor = UIColor.asset(.main)
+    }
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+        setConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setup() {
+        backgroundColor = .clear
+        contentView.backgroundColor = UIColor.asset(.gray4)
+        contentView.layer.cornerRadius = 8
+        contentView.clipsToBounds = true
+        selectionStyle = .none
+        
+        contentView.addSubview(leftContentStackView)
+        contentView.addSubview(rightContentStackView)
+        
+        leftContentStackView.addArrangedSubview(kickboardImageView)
+        leftContentStackView.addArrangedSubview(infoStackView)
+        
+        [kickboardIdLabel, usageTimeLabel, distanceLabel].forEach {
+            infoStackView.addArrangedSubview($0)
+        }
+        
+        [dateLabel, priceLabel].forEach {
+            rightContentStackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func setConstraints() {
+        contentView.snp.makeConstraints { make in
+            make.width.equalTo(370)
+            make.height.equalTo(100)
+            make.center.equalToSuperview()
+            make.leading.equalTo(20)
+            make.trailing.equalTo(-20)
+        }
 
+        kickboardImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(50)
+        }
+        
+        leftContentStackView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.centerY.equalToSuperview()
+        }
+        
+        rightContentStackView.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-20)
+            make.centerY.equalToSuperview()
+        }
+    }
+    
+    private func configureUI() {
+        // 테스트용 더미 데이터
+        kickboardIdLabel.text = "ABCDEF"
+        usageTimeLabel.text = "사용시간: 10:00 ~ 10:30(30분)"
+        distanceLabel.text = "이동거리: 0.5km"
+        dateLabel.text = "2025.04.30"
+        priceLabel.text = "9,999원"
+    }
+    
+    func configure(with model: UsageHistory) {
+        kickboardIdLabel.text = model.kickboardId
+        usageTimeLabel.text = "사용시간: \(model.usageTime)"
+        distanceLabel.text = "이동거리: \(model.distance)km"
+        dateLabel.text = model.date
+        priceLabel.text = "\(model.price)원"
+    }
 }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
@@ -12,16 +12,15 @@ import Then
 
 final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
     
-    // MARK: - Properties
-    
     // MARK: - UI Components
-
+    
     private lazy var tableView = UITableView().then {
         $0.backgroundColor = .clear
         $0.separatorStyle = .none
         $0.register(UsageHistoryTableViewCell.self, forCellReuseIdentifier: UsageHistoryTableViewCell.usageHistoryCellid)
     }
     
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,10 +32,12 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Methods
+    
     private func setup() {
         backgroundColor = .systemBackground
         addSubviews(tableView)
-
+        
         tableView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(20)
             make.leading.trailing.equalToSuperview()
@@ -70,7 +71,7 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
     func numberOfSections(in tableView: UITableView) -> Int {
         return 3 // 섹션 3개로 설정
     }
-
+    
     // numberOfRowsInSection 수정
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1 // 각 섹션당 1개의 셀만 표시

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
@@ -1,0 +1,26 @@
+//
+//  UsageHistoryView.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class UsageHistoryView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setup() {
+        backgroundColor = .systemBackground
+    }
+}

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
@@ -10,10 +10,23 @@ import UIKit
 import SnapKit
 import Then
 
-final class UsageHistoryView: UIView {
+final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+
+    private lazy var tableView = UITableView().then {
+        $0.backgroundColor = .clear
+        $0.separatorStyle = .none
+        $0.register(UsageHistoryTableViewCell.self, forCellReuseIdentifier: UsageHistoryTableViewCell.usageHistoryCellid)
+    }
+    
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        tableViewDelegate()
     }
     
     required init?(coder: NSCoder) {
@@ -22,5 +35,58 @@ final class UsageHistoryView: UIView {
     
     private func setup() {
         backgroundColor = .systemBackground
+        addSubviews(tableView)
+
+        tableView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(20)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-20)
+        }
+        
+        tableView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+    }
+    
+    private func tableViewDelegate() {
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+    
+    // 테이블뷰의 각 섹션의 헤더 높이를 설정 (헤더 높이 0으로 설정)
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 0
+    }
+    
+    //푸터에 특별한 내용을 표시하지 않고 단순히 간격을 주기 위한 용도로 사용
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+    
+    // 푸터의 높이를 20포인트로 설정 (셀 간의 간격)
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 20
+    }
+    
+    // numberOfSections 메서드 추가
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 3 // 섹션 3개로 설정
+    }
+
+    // numberOfRowsInSection 수정
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1 // 각 섹션당 1개의 셀만 표시
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: UsageHistoryTableViewCell.usageHistoryCellid, for: indexPath) as? UsageHistoryTableViewCell else {
+            return UITableViewCell()
+        }
+        // 실제 데이터로 구성할 때 아래와 같이 적으면 됨
+        // cell.configure(with: yourDataModel)
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        100
     }
 }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
@@ -1,0 +1,22 @@
+//
+//  UsageHistoryViewController.swift
+//  TeamProject
+//
+//  Created by iOS study on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+
+final class UsageHistoryViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationBar()
+    }
+    
+    private func setupNavigationBar() {
+        navigationItem.title = "이용 내역"
+    }
+}

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
@@ -11,12 +11,26 @@ import SnapKit
 
 final class UsageHistoryViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    private var usageHistoryView = UsageHistoryView()
+       
+    // MARK: - View Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
+        setupUsageHistoryView()
     }
+    
+    // MARK: - Methods
     
     private func setupNavigationBar() {
         navigationItem.title = "이용 내역"
+    }
+    
+    private func setupUsageHistoryView() {
+        view.addSubview(usageHistoryView)
+        usageHistoryView.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
 }

--- a/TeamProject/TeamProject/protocol/DelegateProtocol.swift
+++ b/TeamProject/TeamProject/protocol/DelegateProtocol.swift
@@ -13,3 +13,8 @@ protocol LoginViewContollerProtocol: AnyObject {
 protocol LogoutViewControllerProtocol: AnyObject {
     func logoutButtonTapped()
 }
+
+protocol MyPageTableViewCellProtocol: AnyObject {
+    func registrationHistoryButtonTapped()
+    func usageHistoryButtonTapped()
+}


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 이용 내역, 등록 내역 화면 연결 및 UI 구현
 - 기존 마이페이지 화살표 출력 오류 수정

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- Model 작성 2건 있습니다. (RegistrationHistory, UsageHistory) 현재 ViewComponents 폴더에 있는데 Model로 옮길 예정입니다. 화면 전환은 > 버튼을 누르면 갈 수 있습니다. 고객센터 하위 3개의 라벨은 화면 구현 및 push로 화면전환 기능 구현하지 않았습니다. 이후 작업은 로그인 로직 검증 할 예정입니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro  | <img src = "https://github.com/user-attachments/assets/012d4ac7-4227-4ace-a270-2f1fd3908686" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #21 
