### PR TITLE
[Feat] #25 - 킥보드 등록 페이지에서 상세 모달 + 마크 삭제 기능

### DIFF
--- a/TeamProject/TeamProject/App/AppDelegate.swift
+++ b/TeamProject/TeamProject/App/AppDelegate.swift
@@ -13,11 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        if let apiKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_API_KEY") as? String {
-            SDKInitializer.InitSDK(appKey: apiKey)
-        } else {
-            fatalError("KAKAO_API 키를 읽어올 수 없습니다.")
-        }
+        SDKInitializer.InitSDK(appKey: "d6b052fb04b20a9be1fbb390a64bff21")
+      
         return true
     }
 

--- a/TeamProject/TeamProject/CoreData/CoreDataManager.swift
+++ b/TeamProject/TeamProject/CoreData/CoreDataManager.swift
@@ -47,6 +47,19 @@ final class CoreDataManager {
         saveContext()
     }
     
+    func deleteRecord(with identifier: UUID) {
+        let fetchRequest: NSFetchRequest<KickBoardRecordEntity> = KickBoardRecordEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "kickboardIdentifier == %@", identifier as CVarArg)
+
+        do {
+            let results = try context.fetch(fetchRequest)
+            results.forEach { context.delete($0) }
+            saveContext()
+        } catch {
+            print("Delete error: \(error.localizedDescription)")
+        }
+    }
+    
     func fetchAllRecords() -> [KickBoardRecord] {
         let request: NSFetchRequest<KickBoardRecordEntity> = KickBoardRecordEntity.fetchRequest()
         

--- a/TeamProject/TeamProject/MainViewController.swift
+++ b/TeamProject/TeamProject/MainViewController.swift
@@ -26,15 +26,22 @@ final class MainViewController: UITabBarController {
     private func setTabBar() {
         let font = UIFont.fontGuide(.TabBarTitle)
         let bottomTabBar = UITabBarAppearance()
-        bottomTabBar.configureWithOpaqueBackground()
-        bottomTabBar.stackedLayoutAppearance.configureWithDefault(for: .inline)
-        bottomTabBar.stackedLayoutAppearance.normal.titleTextAttributes = [.font: font]
-        bottomTabBar.stackedLayoutAppearance.selected.titleTextAttributes = [.font: font]
-        tabBar.standardAppearance = bottomTabBar
         
+        bottomTabBar.configureWithOpaqueBackground()
+        
+        let tabItem = bottomTabBar.stackedLayoutAppearance
+        
+        tabItem.configureWithDefault(for: .inline)
+        tabItem.normal.titleTextAttributes = [.font: font]
+        tabItem.selected.titleTextAttributes = [.font: font]
+
+        let offset = UIOffset(horizontal: 0, vertical: -6)
+        tabItem.normal.titlePositionAdjustment = offset
+        tabItem.selected.titlePositionAdjustment = offset
+        
+        tabBar.standardAppearance = bottomTabBar
         tabBar.tintColor = UIColor.asset(.main)
         tabBar.backgroundColor = .systemBackground
-
     }
     
     // MARK: - SetAttribute

--- a/TeamProject/TeamProject/Utility/Literals/FontLiterals.swift
+++ b/TeamProject/TeamProject/Utility/Literals/FontLiterals.swift
@@ -27,6 +27,7 @@ enum FontLiterals {
     case RentKickboardID
     case RentBasicCharge
     case RentHourlyCharge
+    case RentButtonText
     case RentPauseButtonText
     case RentReturnButtonText
 
@@ -82,7 +83,7 @@ extension FontLiterals {
         case .SignUpButtonText: return 21
 
         case .RentKickboardID: return 23
-        case .RentBasicCharge, .RentHourlyCharge,
+        case .RentBasicCharge, .RentHourlyCharge, .RentButtonText,
              .RentPauseButtonText, .RentReturnButtonText: return 17
 
         case .RegistrationModalTitle: return 17
@@ -125,6 +126,7 @@ extension FontLiterals {
              .RentKickboardID,
              .RentBasicCharge,
              .RentHourlyCharge,
+             .RentButtonText,
              .RentPauseButtonText,
              .RentReturnButtonText,
              .RegistrationBasicCharge,

--- a/TeamProject/TeamProject/Utility/Literals/SizeLiterals.swift
+++ b/TeamProject/TeamProject/Utility/Literals/SizeLiterals.swift
@@ -10,7 +10,7 @@ import UIKit
 struct SizeLiterals {
     struct Screen {
         static let screenWidth: CGFloat = UIScreen.main.bounds.width
-        /// 사용법 :  $0.height.equalTo(SizeLiterals.Screen.screenHeight * 25 / 402)
+        /// 사용법 :  $0.width.equalTo(SizeLiterals.Screen.screenWidth * 25 / 402)
         /// ==> 기기별 넓이 25사이즈 대응
         static let screenHeight: CGFloat = UIScreen.main.bounds.height
         /// 사용법 :  $0.height.equalTo(SizeLiterals.Screen.screenHeight * 25 / 874)

--- a/TeamProject/TeamProject/View/Common/KakaoMapViewController.swift
+++ b/TeamProject/TeamProject/View/Common/KakaoMapViewController.swift
@@ -82,7 +82,7 @@ class KakaoMapViewController: UIViewController, MapControllerDelegate, KakaoMapE
 
         let layerOption = LabelLayerOptions(
             layerID: "PoiLayer",
-            competitionType: .none,
+            competitionType: .all,
             competitionUnit: .symbolFirst,
             orderType: .rank,
             zOrder: 10

--- a/TeamProject/TeamProject/View/Common/KakaoMapViewController.swift
+++ b/TeamProject/TeamProject/View/Common/KakaoMapViewController.swift
@@ -82,10 +82,10 @@ class KakaoMapViewController: UIViewController, MapControllerDelegate, KakaoMapE
 
         let layerOption = LabelLayerOptions(
             layerID: "PoiLayer",
-            competitionType: .all,
+            competitionType: .none,
             competitionUnit: .symbolFirst,
             orderType: .rank,
-            zOrder: 10
+            zOrder: 100
         )
         _ = manager.addLabelLayer(option: layerOption)
     }

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/DeleteModelViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/DeleteModelViewController.swift
@@ -39,35 +39,32 @@ final class DeleteModalViewController: UIViewController {
         $0.image = ImageLiterals.kickboard
     }
 
-    private lazy var kickboardID = UILabel().then {
+    private let kickboardID = UILabel().then {
         $0.font = UIFont.fontGuide(.RentKickboardID)
         $0.textColor = .label
         $0.textAlignment = .left
-        $0.text = kickboardIDText
     }
 
-    private lazy var basicChargeTitle = UILabel().then {
+    private let basicChargeTitle = UILabel().then {
         $0.font = UIFont.fontGuide(.RentBasicCharge)
         $0.textColor = UIColor.asset(.gray3)
         $0.text = "기본 이용료:"
     }
 
-    private lazy var basicCharge = UILabel().then {
+    private let basicCharge = UILabel().then {
         $0.font = UIFont.fontGuide(.RentBasicCharge)
         $0.textColor = UIColor.asset(.gray3)
-        $0.text = basicChargeText
     }
 
-    private lazy var hourlyChargeTitle = UILabel().then {
+    private let hourlyChargeTitle = UILabel().then {
         $0.font = UIFont.fontGuide(.RentHourlyCharge)
         $0.textColor = UIColor.asset(.gray3)
         $0.text = "시간당 요금:"
     }
 
-    private lazy var hourlyCharge = UILabel().then {
+    private let hourlyCharge = UILabel().then {
         $0.font = UIFont.fontGuide(.RentHourlyCharge)
         $0.textColor = UIColor.asset(.gray3)
-        $0.text = hourlyChargeText
     }
 
     private let deleteButton = UIButton().then {
@@ -86,9 +83,12 @@ final class DeleteModalViewController: UIViewController {
         deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
     }
 
-    // MARK: - Style/Layout
+    // MARK: - Layout Helper
     private func setStyle() {
         view.backgroundColor = .systemBackground
+        kickboardID.text = kickboardIDText
+        basicCharge.text = basicChargeText
+        hourlyCharge.text = hourlyChargeText
     }
 
     private func setLayout() {
@@ -136,9 +136,8 @@ final class DeleteModalViewController: UIViewController {
         }
     }
 
-    // MARK: - Actions
+    // MARK: - Methods
     @objc private func didTapDeleteButton() {
-        // 삭제 동작 처리 로직
         print("삭제하기 버튼이 눌렸습니다.")
         viewmodel.deleteKickBoardRecord(kickBoardIdentifier)
         dismiss(animated: true)

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/DeleteModelViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/DeleteModelViewController.swift
@@ -1,0 +1,146 @@
+//
+//  DeleteModelViewController.swift
+//  TeamProject
+//
+//  Created by tlswo on 4/29/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class DeleteModalViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let viewmodel = KickBoardRecordViewModel.shared
+
+    private var kickboardIDText: String
+    private var basicChargeText: String
+    private var hourlyChargeText: String
+    private var kickBoardIdentifier: UUID
+    
+    // MARK: - Initializer
+    init(kickboardID: UUID, basicCharge: Int, hourlyCharge: Int) {
+        self.kickBoardIdentifier = kickboardID
+        self.kickboardIDText = kickboardID.uuidString
+        self.basicChargeText = String(basicCharge)
+        self.hourlyChargeText = String(hourlyCharge)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI Components
+    private let kickboardImage = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = ImageLiterals.kickboard
+    }
+
+    private lazy var kickboardID = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentKickboardID)
+        $0.textColor = .label
+        $0.textAlignment = .left
+        $0.text = kickboardIDText
+    }
+
+    private lazy var basicChargeTitle = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentBasicCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.text = "기본 이용료:"
+    }
+
+    private lazy var basicCharge = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentBasicCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.text = basicChargeText
+    }
+
+    private lazy var hourlyChargeTitle = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentHourlyCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.text = "시간당 요금:"
+    }
+
+    private lazy var hourlyCharge = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentHourlyCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.text = hourlyChargeText
+    }
+
+    private let deleteButton = UIButton().then {
+        $0.setTitle("삭제하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = UIColor.systemRed
+        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        $0.layer.cornerRadius = 8
+    }
+
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setStyle()
+        setLayout()
+        deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
+    }
+
+    // MARK: - Style/Layout
+    private func setStyle() {
+        view.backgroundColor = .systemBackground
+    }
+
+    private func setLayout() {
+        view.addSubviews(kickboardImage, kickboardID,
+                         basicChargeTitle, basicCharge,
+                         hourlyChargeTitle, hourlyCharge,
+                         deleteButton)
+
+        kickboardImage.snp.makeConstraints {
+            $0.width.height.equalTo(112)
+            $0.leading.equalToSuperview().inset(50)
+            $0.top.equalToSuperview().offset(38)
+        }
+
+        kickboardID.snp.makeConstraints {
+            $0.top.equalTo(kickboardImage)
+            $0.leading.equalTo(kickboardImage.snp.trailing).offset(17)
+        }
+
+        basicChargeTitle.snp.makeConstraints {
+            $0.top.equalTo(kickboardID.snp.bottom).offset(14)
+            $0.leading.equalTo(kickboardID.snp.leading)
+        }
+
+        basicCharge.snp.makeConstraints {
+            $0.top.equalTo(basicChargeTitle.snp.top)
+            $0.leading.equalTo(basicChargeTitle.snp.trailing).offset(10)
+        }
+
+        hourlyChargeTitle.snp.makeConstraints {
+            $0.top.equalTo(basicChargeTitle.snp.bottom).offset(10)
+            $0.leading.equalTo(kickboardID.snp.leading)
+        }
+
+        hourlyCharge.snp.makeConstraints {
+            $0.top.equalTo(hourlyChargeTitle.snp.top)
+            $0.leading.equalTo(hourlyChargeTitle.snp.trailing).offset(10)
+        }
+
+        deleteButton.snp.makeConstraints {
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 333 / 402)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 45 / 874)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-39)
+            $0.centerX.equalToSuperview()
+        }
+    }
+
+    // MARK: - Actions
+    @objc private func didTapDeleteButton() {
+        // 삭제 동작 처리 로직
+        print("삭제하기 버튼이 눌렸습니다.")
+        viewmodel.deleteKickBoardRecord(kickBoardIdentifier)
+        dismiss(animated: true)
+    }
+}

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -87,12 +87,12 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
 
     //addView 성공 이벤트 delegate. 추가적으로 수행할 작업을 진행한다.
     override func addViewSucceeded(_ viewName: String, viewInfoName: String) {
-        print("AddView succeeded: \(viewName), \(viewInfoName)")
-        let view = mapController?.getView("mapview") as! KakaoMap
-        view.viewRect = mapViewContainer!.bounds //뷰 add 도중에 resize 이벤트가 발생한 경우 이벤트를 받지 못했을 수 있음. 원하는 뷰 사이즈로 재조정.
-        view.eventDelegate = self
-        createLabelLayer()
-        createPoiStyle()
+        super.addViewSucceeded(viewName, viewInfoName: viewInfoName)
+
+//        let view = mapController?.getView("mapview") as! KakaoMap
+//        view.viewRect = mapViewContainer!.bounds
+//        view.eventDelegate = self
+        //뷰 add 도중에 resize 이벤트가 발생한 경우 이벤트를 받지 못했을 수 있음. 원하는 뷰 사이즈로 재조정.
         setupBindings()
         viewmodel.fetchKickBoardRecords()
     }
@@ -115,46 +115,6 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
 
         _observerAdded = false
-    }
-
-    private func createLabelLayer() {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap else { return }
-        let manager = mapView.getLabelManager()
-
-        let layerOption = LabelLayerOptions(
-            layerID: "PoiLayer",
-            competitionType: .none,
-            competitionUnit: .symbolFirst,
-            orderType: .rank,
-            zOrder: 10
-        )
-        _ = manager.addLabelLayer(option: layerOption)
-    }
-
-    private func createPoiStyle() {
-        guard let mapView = mapController?.getView("mapview") as? KakaoMap else { return }
-        let manager = mapView.getLabelManager()
-
-        if let originalImage = UIImage(named: "kickboard") {
-            let targetSize = CGSize(width: 30, height: 30)
-            let renderer = UIGraphicsImageRenderer(size: targetSize)
-            let resizedImage = renderer.image { _ in
-                originalImage.draw(in: CGRect(origin: .zero, size: targetSize))
-            }
-
-            let iconStyle = PoiIconStyle(
-                symbol: resizedImage,
-                anchorPoint: CGPoint(x: 0.5, y: 1.0)
-            )
-
-            let poiStyle = PoiStyle(styleID: "kickboardMarkStyleID", styles: [
-                PerLevelPoiStyle(iconStyle: iconStyle, level: 5),
-                ])
-
-            manager.addPoiStyle(poiStyle)
-        } else {
-            print("kickboard 이미지 로드 실패")
-        }
     }
 
     private func setupBindings() {
@@ -187,9 +147,9 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
 
 // MARK: - Extension
 
-extension KickBoardRegisterViewController: KakaoMapEventDelegate {
+extension KickBoardRegisterViewController {
     func terrainDidLongPressed(kakaoMap: KakaoMap, position: MapPoint) {
-        let mapView: KakaoMap = mapController?.getView("mapview") as! KakaoMap
+        guard let mapView = mapController?.getView("mapview") as? KakaoMap else { return }
         let manager = mapView.getLabelManager()
         let layer = manager.getLabelLayer(layerID: "PoiLayer")
         let option = PoiOptions(styleID: "kickboardMarkStyleID")

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -10,63 +10,63 @@ import UIKit
 
 import KakaoMapsSDK
 
-class KickBoardRegisterViewController: KakaoMapViewController {
-    
+final class KickBoardRegisterViewController: KakaoMapViewController {
+
     // MARK: - Properties
-    
-    var _observerAdded: Bool
-    var _appear: Bool
-    var isViewAdded = false
-    var lastAddedPoi: Poi?
-    
+
+    private var _observerAdded: Bool
+    private var _appear: Bool
+    private var isViewAdded = false
+    private var lastAddedPoi: Poi?
+
     private let viewmodel = KickBoardRecordViewModel.shared
-    
+
     // MARK: - Initializer
-    
+
     required init?(coder aDecoder: NSCoder) {
         _observerAdded = false
         _appear = false
         super.init(coder: aDecoder)
         auth = false
     }
-    
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         _observerAdded = false
         _appear = false
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         auth = false
     }
-    
+
     // MARK: - View Life Cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         addObservers()
         _appear = true
         if mapController?.isEnginePrepared == false {
             mapController?.prepareEngine()
         }
-        
+
         if mapController?.isEngineActive == false {
             mapController?.activateEngine()
         }
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         _appear = false
-        mapController?.pauseEngine()  //렌더링 중지.
+        mapController?.pauseEngine() //렌더링 중지.
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         removeObservers()
-        mapController?.resetEngine()     //엔진 정지. 추가되었던 ViewBase들이 삭제된다.
+        mapController?.resetEngine() //엔진 정지. 추가되었던 ViewBase들이 삭제된다.
     }
-    
+
     // MARK: - Methods
-    
+
     // 인증 성공시 delegate 호출.
     func authenticationSucceeded() {
         // 일반적으로 내부적으로 인증과정 진행하여 성공한 경우 별도의 작업은 필요하지 않으나,
@@ -74,7 +74,7 @@ class KickBoardRegisterViewController: KakaoMapViewController {
         if auth == false {
             auth = true
         }
-        
+
         if _appear && mapController?.isEngineActive == false {
             mapController?.activateEngine()
         }
@@ -83,62 +83,44 @@ class KickBoardRegisterViewController: KakaoMapViewController {
             isViewAdded = true
         }
     }
-    
-    override func addViews() {
-        //여기에서 그릴 View(KakaoMap, Roadview)들을 추가한다.
-        let defaultPosition: MapPoint = MapPoint(longitude: 127.108678, latitude: 37.402001)
-        //지도(KakaoMap)를 그리기 위한 viewInfo를 생성
-        let mapviewInfo: MapviewInfo = MapviewInfo(viewName: "mapview", viewInfoName: "map", defaultPosition: defaultPosition, defaultLevel: 7)
-        mapController?.addView(mapviewInfo)
-        
-    }
-    
+
+
     //addView 성공 이벤트 delegate. 추가적으로 수행할 작업을 진행한다.
     override func addViewSucceeded(_ viewName: String, viewInfoName: String) {
         print("AddView succeeded: \(viewName), \(viewInfoName)")
         let view = mapController?.getView("mapview") as! KakaoMap
-        view.viewRect = mapViewContainer!.bounds    //뷰 add 도중에 resize 이벤트가 발생한 경우 이벤트를 받지 못했을 수 있음. 원하는 뷰 사이즈로 재조정.
+        view.viewRect = mapViewContainer!.bounds //뷰 add 도중에 resize 이벤트가 발생한 경우 이벤트를 받지 못했을 수 있음. 원하는 뷰 사이즈로 재조정.
         view.eventDelegate = self
         createLabelLayer()
         createPoiStyle()
-        viewInit(viewName: viewName)
         setupBindings()
         viewmodel.fetchKickBoardRecords()
     }
-    
-    func viewInit(viewName: String) {
-        print("OK")
-    }
-    
-    //addView 실패 이벤트 delegate. 실패에 대한 오류 처리를 진행한다.
-    override func addViewFailed(_ viewName: String, viewInfoName: String) {
-        print("AddView failed: \(viewName), \(viewInfoName)")
-    }
-    
+
     //Container 뷰가 리사이즈 되었을때 호출된다. 변경된 크기에 맞게 ViewBase들의 크기를 조절할 필요가 있는 경우 여기에서 수행한다.
-    func containerDidResized(_ size: CGSize) {
+    private func containerDidResized(_ size: CGSize) {
         let mapView: KakaoMap? = mapController?.getView("mapview") as? KakaoMap
-        mapView?.viewRect = CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: size)   //지도뷰의 크기를 리사이즈된 크기로 지정한다.
+        mapView?.viewRect = CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: size) //지도뷰의 크기를 리사이즈된 크기로 지정한다.
     }
-    
-    func addObservers(){
+
+    private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
-        
+
         _observerAdded = true
     }
-    
-    func removeObservers(){
+
+    private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-        
+
         _observerAdded = false
     }
-    
+
     private func createLabelLayer() {
         guard let mapView = mapController?.getView("mapview") as? KakaoMap else { return }
         let manager = mapView.getLabelManager()
-        
+
         let layerOption = LabelLayerOptions(
             layerID: "PoiLayer",
             competitionType: .none,
@@ -148,18 +130,18 @@ class KickBoardRegisterViewController: KakaoMapViewController {
         )
         _ = manager.addLabelLayer(option: layerOption)
     }
-    
+
     private func createPoiStyle() {
         guard let mapView = mapController?.getView("mapview") as? KakaoMap else { return }
         let manager = mapView.getLabelManager()
-        
+
         if let originalImage = UIImage(named: "kickboard") {
             let targetSize = CGSize(width: 30, height: 30)
             let renderer = UIGraphicsImageRenderer(size: targetSize)
             let resizedImage = renderer.image { _ in
                 originalImage.draw(in: CGRect(origin: .zero, size: targetSize))
             }
-            
+
             let iconStyle = PoiIconStyle(
                 symbol: resizedImage,
                 anchorPoint: CGPoint(x: 0.5, y: 1.0)
@@ -167,14 +149,14 @@ class KickBoardRegisterViewController: KakaoMapViewController {
 
             let poiStyle = PoiStyle(styleID: "kickboardMarkStyleID", styles: [
                 PerLevelPoiStyle(iconStyle: iconStyle, level: 5),
-            ])
-            
+                ])
+
             manager.addPoiStyle(poiStyle)
         } else {
             print("kickboard 이미지 로드 실패")
         }
     }
-    
+
     private func setupBindings() {
         viewmodel.onRecordsUpdated = { [weak self] records in
             guard self != nil else { return }
@@ -184,21 +166,21 @@ class KickBoardRegisterViewController: KakaoMapViewController {
                 let position = MapPoint(longitude: record.longitude, latitude: record.latitude)
                 let option = PoiOptions(styleID: "kickboardMarkStyleID")
                 option.clickable = true
-                
+
                 if let poi = layer.addPoi(option: option, at: position) {
                     poi.show()
                 }
             }
         }
     }
-    
+
     // MARK: - @objc Methods
 
-    @objc func willResignActive(){
-        mapController?.pauseEngine()  //뷰가 inactive 상태로 전환되는 경우 렌더링 중인 경우 렌더링을 중단.
+    @objc func willResignActive() {
+        mapController?.pauseEngine() //뷰가 inactive 상태로 전환되는 경우 렌더링 중인 경우 렌더링을 중단.
     }
-    
-    @objc func didBecomeActive(){
+
+    @objc func didBecomeActive() {
         mapController?.activateEngine() //뷰가 active 상태가 되면 렌더링 시작. 엔진은 미리 시작된 상태여야 함.
     }
 }
@@ -212,15 +194,15 @@ extension KickBoardRegisterViewController: KakaoMapEventDelegate {
         let layer = manager.getLabelLayer(layerID: "PoiLayer")
         let option = PoiOptions(styleID: "kickboardMarkStyleID")
         option.clickable = true
-        
+
         if let poi = layer?.addPoi(option: option, at: position) {
             poi.show()
             self.lastAddedPoi = poi
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             guard let self else { return }
-            
+
             let alertVC = RegisterKickboardAlertViewController()
             alertVC.delegate = self
             alertVC.latitude = position.wgsCoord.latitude

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -46,13 +46,6 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
     override func viewWillAppear(_ animated: Bool) {
         addObservers()
         _appear = true
-        if mapController?.isEnginePrepared == false {
-            mapController?.prepareEngine()
-        }
-
-        if mapController?.isEngineActive == false {
-            mapController?.activateEngine()
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -11,63 +11,63 @@ import UIKit
 import KakaoMapsSDK
 
 final class KickBoardRegisterViewController: KakaoMapViewController {
-
+    
     // MARK: - Properties
-
+    
     private var _observerAdded: Bool
     private var _appear: Bool
     private var isViewAdded = false
     private var lastAddedPoi: Poi?
-
+    
     private let viewmodel = KickBoardRecordViewModel.shared
     
     private var poiToRecordMap: [String: KickBoardRecord] = [:]
-
+    
     // MARK: - Initializer
-
+    
     required init?(coder aDecoder: NSCoder) {
         _observerAdded = false
         _appear = false
         super.init(coder: aDecoder)
         auth = false
     }
-
+    
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         _observerAdded = false
         _appear = false
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         auth = false
     }
-
+    
     // MARK: - View Life Cycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-
+    
     override func viewWillAppear(_ animated: Bool) {
         addObservers()
         _appear = true
         if mapController?.isEnginePrepared == false {
-          mapController?.prepareEngine()
+            mapController?.prepareEngine()
         }
         if mapController?.isEngineActive == false {
-          mapController?.activateEngine()
+            mapController?.activateEngine()
         }
-      }
-
+    }
+    
     override func viewWillDisappear(_ animated: Bool) {
         _appear = false
         mapController?.pauseEngine() //렌더링 중지.
     }
-
+    
     override func viewDidDisappear(_ animated: Bool) {
         removeObservers()
         mapController?.resetEngine() //엔진 정지. 추가되었던 ViewBase들이 삭제된다.
     }
-
+    
     // MARK: - Methods
-
+    
     // 인증 성공시 delegate 호출.
     func authenticationSucceeded() {
         // 일반적으로 내부적으로 인증과정 진행하여 성공한 경우 별도의 작업은 필요하지 않으나,
@@ -75,7 +75,7 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
         if auth == false {
             auth = true
         }
-
+        
         if _appear && mapController?.isEngineActive == false {
             mapController?.activateEngine()
         }
@@ -84,50 +84,54 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
             isViewAdded = true
         }
     }
-
-
+    
+    
     //addView 성공 이벤트 delegate. 추가적으로 수행할 작업을 진행한다.
     override func addViewSucceeded(_ viewName: String, viewInfoName: String) {
         super.addViewSucceeded(viewName, viewInfoName: viewInfoName)
-
-//        let view = mapController?.getView("mapview") as! KakaoMap
-//        view.viewRect = mapViewContainer!.bounds
-//        view.eventDelegate = self
+        
+        //        let view = mapController?.getView("mapview") as! KakaoMap
+        //        view.viewRect = mapViewContainer!.bounds
+        //        view.eventDelegate = self
         //뷰 add 도중에 resize 이벤트가 발생한 경우 이벤트를 받지 못했을 수 있음. 원하는 뷰 사이즈로 재조정.
         setupBindings()
         viewmodel.fetchKickBoardRecords()
     }
-
+    
     //Container 뷰가 리사이즈 되었을때 호출된다. 변경된 크기에 맞게 ViewBase들의 크기를 조절할 필요가 있는 경우 여기에서 수행한다.
     private func containerDidResized(_ size: CGSize) {
         let mapView: KakaoMap? = mapController?.getView("mapview") as? KakaoMap
         mapView?.viewRect = CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: size) //지도뷰의 크기를 리사이즈된 크기로 지정한다.
     }
-
+    
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
-
+        
         _observerAdded = true
     }
-
+    
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-
+        
         _observerAdded = false
     }
-
+    
     private func setupBindings() {
         viewmodel.onRecordsUpdated = { [weak self] records in
             guard self != nil else { return }
             guard let mapView = self?.mapController?.getView("mapview") as? KakaoMap else { return }
             guard let layer = mapView.getLabelManager().getLabelLayer(layerID: "PoiLayer") else { return }
+            
+            layer.clearAllItems()
+            self?.poiToRecordMap.removeAll()
+                        
             for record in records {
                 let position = MapPoint(longitude: record.longitude, latitude: record.latitude)
                 let option = PoiOptions(styleID: "kickboardMarkStyleID")
                 option.clickable = true
-
+                
                 if let poi = layer.addPoi(option: option, at: position) {
                     poi.show()
                     self?.poiToRecordMap[poi.itemID] = record
@@ -135,13 +139,13 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
             }
         }
     }
-
+    
     // MARK: - @objc Methods
-
+    
     @objc func willResignActive() {
         mapController?.pauseEngine() //뷰가 inactive 상태로 전환되는 경우 렌더링 중인 경우 렌더링을 중단.
     }
-
+    
     @objc func didBecomeActive() {
         mapController?.activateEngine() //뷰가 active 상태가 되면 렌더링 시작. 엔진은 미리 시작된 상태여야 함.
     }
@@ -156,15 +160,15 @@ extension KickBoardRegisterViewController {
         let layer = manager.getLabelLayer(layerID: "PoiLayer")
         let option = PoiOptions(styleID: "kickboardMarkStyleID")
         option.clickable = true
-
+        
         if let poi = layer?.addPoi(option: option, at: position) {
             poi.show()
             self.lastAddedPoi = poi
         }
-
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             guard let self else { return }
-
+            
             let alertVC = RegisterKickboardAlertViewController()
             alertVC.delegate = self
             alertVC.latitude = position.wgsCoord.latitude
@@ -181,6 +185,20 @@ extension KickBoardRegisterViewController {
             return
         }
         print("Tapped record: \(record)")
+        
+        let vc = DeleteModalViewController(
+            kickboardID: record.kickboardIdentifier,
+            basicCharge: record.basicCharge,
+            hourlyCharge: record.hourlyCharge
+        )
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom(resolver: { _  in
+                return SizeLiterals.Screen.screenHeight * 257 / 874
+            })]
+            sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 20
+        }
+        present(vc, animated: true, completion: nil)
     }
 }
 

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -46,7 +46,13 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
     override func viewWillAppear(_ animated: Bool) {
         addObservers()
         _appear = true
-    }
+        if mapController?.isEnginePrepared == false {
+          mapController?.prepareEngine()
+        }
+        if mapController?.isEngineActive == false {
+          mapController?.activateEngine()
+        }
+      }
 
     override func viewWillDisappear(_ animated: Bool) {
         _appear = false
@@ -164,6 +170,10 @@ extension KickBoardRegisterViewController {
             alertVC.modalPresentationStyle = .overFullScreen
             self.present(alertVC, animated: true)
         }
+    }
+    
+    func poiDidTapped(kakaoMap: KakaoMap, layerID: String, poiID: String, position: MapPoint) {
+        print("poiDidTapped")
     }
 }
 

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/KickBoardRegisterViewController.swift
@@ -20,6 +20,8 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
     private var lastAddedPoi: Poi?
 
     private let viewmodel = KickBoardRecordViewModel.shared
+    
+    private var poiToRecordMap: [String: KickBoardRecord] = [:]
 
     // MARK: - Initializer
 
@@ -128,6 +130,7 @@ final class KickBoardRegisterViewController: KakaoMapViewController {
 
                 if let poi = layer.addPoi(option: option, at: position) {
                     poi.show()
+                    self?.poiToRecordMap[poi.itemID] = record
                 }
             }
         }
@@ -173,7 +176,11 @@ extension KickBoardRegisterViewController {
     }
     
     func poiDidTapped(kakaoMap: KakaoMap, layerID: String, poiID: String, position: MapPoint) {
-        print("poiDidTapped")
+        guard let record = poiToRecordMap[poiID] else {
+            print("Record not found for tapped POI")
+            return
+        }
+        print("Tapped record: \(record)")
     }
 }
 

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/RegisterKickboardAlertViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/RegisterKickboardAlertViewController.swift
@@ -27,80 +27,75 @@ class RegisterKickboardAlertViewController: UIViewController {
     var recognitionNumber: UUID = UUID()
     
     // MARK: - UI Components
-    
-    private let backgroundView = UIView()
-    
-    private lazy var containerView = UIView().then {
+    private let containerView = UIView().then {
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 8
     }
     
-    private lazy var titleLabel = UILabel().then {
+    private let titleLabel = UILabel().then {
         $0.text = "현재 위치에 등록"
         $0.font = UIFont.boldSystemFont(ofSize: 18)
         $0.textAlignment = .center
     }
     
-    private lazy var infoLabel = UILabel().then {
+    private let infoLabel = UILabel().then {
         $0.font = UIFont.systemFont(ofSize: 13)
         $0.textColor = .secondaryLabel
         $0.numberOfLines = 0
         $0.textAlignment = .center
     }
     
-    private lazy var basicChargeTextField = UITextField().then {
+    private let basicChargeTextField = UITextField().then {
         $0.placeholder = "기본 이용 요금"
         $0.borderStyle = .roundedRect
         $0.backgroundColor = UIColor.systemGray6
         $0.keyboardType = .decimalPad
     }
     
-    private lazy var hourlyChargeTextField = UITextField().then {
+    private let hourlyChargeTextField = UITextField().then {
         $0.placeholder = "시간당 요금"
         $0.borderStyle = .roundedRect
         $0.backgroundColor = UIColor.systemGray6
         $0.keyboardType = .decimalPad
     }
     
-    private lazy var cancelButton = UIButton(type: .system).then {
+    private let cancelButton = UIButton(type: .system).then {
         $0.setTitle("취소", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.backgroundColor = .systemGray3
         $0.layer.cornerRadius = 8
-        $0.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        
     }
     
-    private lazy var registerButton = UIButton(type: .system).then {
+    private let registerButton = UIButton(type: .system).then {
         $0.setTitle("등록", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.backgroundColor = UIColor.systemMint
         $0.layer.cornerRadius = 8
-        $0.addTarget(self, action: #selector(didTapRegister), for: .touchUpInside)
+        
     }
         
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupViews()
-        setupConstraints()
+        setStyle()
+        setLayout()
+        updateInfoLabel()
+        cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        registerButton.addTarget(self, action: #selector(didTapRegister), for: .touchUpInside)
     }
     
     // MARK: - Layout Helper
     
-    private func setupViews() {
+    private func setStyle() {
         view.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-        
-        view.addSubview(containerView)
-        
-        [titleLabel, infoLabel, basicChargeTextField, hourlyChargeTextField, cancelButton, registerButton].forEach {
-            containerView.addSubview($0)
-        }
-        
-        updateInfoLabel()
     }
     
-    private func setupConstraints() {
+    private func setLayout() {
+        view.addSubview(containerView)
+        containerView.addSubviews(titleLabel, infoLabel, basicChargeTextField, hourlyChargeTextField, cancelButton, registerButton)
+        
         containerView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.centerX.equalToSuperview()
@@ -148,10 +143,7 @@ class RegisterKickboardAlertViewController: UIViewController {
     // MARK: - Methods
     
     private func updateInfoLabel() {
-        infoLabel.text = """
-        위도: \(latitude) 경도: \(longitude)
-        킥보드 인식번호: \(recognitionNumber)
-        """
+        infoLabel.text = "위도: \(latitude) 경도: \(longitude) \n킥보드 인식번호: \(recognitionNumber)"
     }
     
     // MARK: - @objc Methods

--- a/TeamProject/TeamProject/View/RentView/RentModalViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentModalViewController.swift
@@ -17,77 +17,77 @@ final class RentModalViewController: UIViewController {
     
     // MARK: - UI Components
 
-    private let kickboardImage = UIImageView().then {
+    private let kickboardImage = UIImageView().then { make in
         let img = ImageLiterals.kickboard
-        $0.contentMode = .scaleAspectFit
-        $0.image = img
+        make.contentMode = .scaleAspectFit
+        make.image = img
     }
 
-    private let kickboardID = UILabel().then {
-        $0.font = UIFont.fontGuide(.RentKickboardID)
-        $0.textColor = .label
-        $0.textAlignment = .left
-        $0.text = "MK111"
+    private let kickboardID = UILabel().then { make in
+        make.font = UIFont.fontGuide(.RentKickboardID)
+        make.textColor = .label
+        make.textAlignment = .left
+        make.text = "MK111"
     }
 
-    private let basicChargeTitle = UILabel().then {
-        $0.font = UIFont.fontGuide(.RentBasicCharge)
-        $0.textColor = UIColor.asset(.gray3)
-        $0.textAlignment = .left
-        $0.text = "기본 이용료:"
+    private let basicChargeTitle = UILabel().then { make in
+        make.font = UIFont.fontGuide(.RentBasicCharge)
+        make.textColor = UIColor.asset(.gray3)
+        make.textAlignment = .left
+        make.text = "기본 이용료:"
     }
-    private let basicCharge = UILabel().then {
-        $0.font = UIFont.fontGuide(.RentBasicCharge)
-        $0.textColor = UIColor.asset(.gray3)
-        $0.textAlignment = .left
-        $0.text = "1,000원"
-    }
-
-    private let hourlyChargeTitle = UILabel().then {
-        $0.font = UIFont.fontGuide(.RentHourlyCharge)
-        $0.textColor = UIColor.asset(.gray3)
-        $0.textAlignment = .left
-        $0.text = "시간당 요금:"
+    private let basicCharge = UILabel().then { make in
+        make.font = UIFont.fontGuide(.RentBasicCharge)
+        make.textColor = UIColor.asset(.gray3)
+        make.textAlignment = .left
+        make.text = "1,000원"
     }
 
-    private let hourlyCharge = UILabel().then {
-        $0.font = UIFont.fontGuide(.RentHourlyCharge)
-        $0.textColor = UIColor.asset(.gray3)
-        $0.textAlignment = .left
-        $0.text = "200원"
+    private let hourlyChargeTitle = UILabel().then { make in
+        make.font = UIFont.fontGuide(.RentHourlyCharge)
+        make.textColor = UIColor.asset(.gray3)
+        make.textAlignment = .left
+        make.text = "시간당 요금:"
     }
 
-    private let rentButton = UIButton().then {
-        $0.setTitle("대여하기", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = UIColor.asset(.main)
-        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
-        $0.layer.cornerRadius = 8
+    private let hourlyCharge = UILabel().then { make in
+        make.font = UIFont.fontGuide(.RentHourlyCharge)
+        make.textColor = UIColor.asset(.gray3)
+        make.textAlignment = .left
+        make.text = "200원"
     }
 
-    private let buttonStackView = UIStackView().then {
-        $0.axis = .horizontal
-        $0.spacing = 16
-        $0.distribution = .fillEqually
-        $0.alignment = .center
-        $0.isHidden = true
+    private let rentButton = UIButton().then { make in
+        make.setTitle("대여하기", for: .normal)
+        make.setTitleColor(.white, for: .normal)
+        make.backgroundColor = UIColor.asset(.main)
+        make.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        make.layer.cornerRadius = 8
     }
 
-    private let pauseButton = UIButton().then {
-        $0.setTitle("일시정지", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = UIColor.asset(.gray1)
-        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
-        $0.layer.cornerRadius = 8
+    private let buttonStackView = UIStackView().then { make in
+        make.axis = .horizontal
+        make.spacing = 16
+        make.distribution = .fillEqually
+        make.alignment = .center
+        make.isHidden = true
+    }
+
+    private let pauseButton = UIButton().then { make in
+        make.setTitle("일시정지", for: .normal)
+        make.setTitleColor(.white, for: .normal)
+        make.backgroundColor = UIColor.asset(.gray1)
+        make.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        make.layer.cornerRadius = 8
     }
 
 
-    private let returnButton = UIButton().then {
-        $0.setTitle("반납하기", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = UIColor.asset(.main)
-        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
-        $0.layer.cornerRadius = 8
+    private let returnButton = UIButton().then { make in
+        make.setTitle("반납하기", for: .normal)
+        make.setTitleColor(.white, for: .normal)
+        make.backgroundColor = UIColor.asset(.main)
+        make.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        make.layer.cornerRadius = 8
     }
     
     // MARK: - View Life Cycle

--- a/TeamProject/TeamProject/View/RentView/RentModalViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentModalViewController.swift
@@ -1,0 +1,197 @@
+//
+//  RentModalViewController.swift
+//  TeamProject
+//
+//  Created by yimkeul on 4/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RentModalViewController: UIViewController {
+
+    // MARK: - Properties
+    //viewmodel
+    
+    // MARK: - UI Components
+
+    private let kickboardImage = UIImageView().then {
+        let img = ImageLiterals.kickboard
+        $0.contentMode = .scaleAspectFit
+        $0.image = img
+    }
+
+    private let kickboardID = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentKickboardID)
+        $0.textColor = .label
+        $0.textAlignment = .left
+        $0.text = "MK111"
+    }
+
+    private let basicChargeTitle = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentBasicCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.textAlignment = .left
+        $0.text = "기본 이용료:"
+    }
+    private let basicCharge = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentBasicCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.textAlignment = .left
+        $0.text = "1,000원"
+    }
+
+    private let hourlyChargeTitle = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentHourlyCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.textAlignment = .left
+        $0.text = "시간당 요금:"
+    }
+
+    private let hourlyCharge = UILabel().then {
+        $0.font = UIFont.fontGuide(.RentHourlyCharge)
+        $0.textColor = UIColor.asset(.gray3)
+        $0.textAlignment = .left
+        $0.text = "200원"
+    }
+
+    private let rentButton = UIButton().then {
+        $0.setTitle("대여하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = UIColor.asset(.main)
+        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        $0.layer.cornerRadius = 8
+    }
+
+    private let buttonStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 16
+        $0.distribution = .fillEqually
+        $0.alignment = .center
+        $0.isHidden = true
+    }
+
+    private let pauseButton = UIButton().then {
+        $0.setTitle("일시정지", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = UIColor.asset(.gray1)
+        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        $0.layer.cornerRadius = 8
+    }
+
+
+    private let returnButton = UIButton().then {
+        $0.setTitle("반납하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = UIColor.asset(.main)
+        $0.titleLabel?.font = UIFont.fontGuide(.RentButtonText)
+        $0.layer.cornerRadius = 8
+    }
+    
+    // MARK: - View Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setStyle()
+        setLayout()
+        rentButton.addTarget(self, action: #selector(didTapRentButton), for: .touchUpInside)
+        pauseButton.addTarget(self, action: #selector(didTapPauseButton), for: .touchUpInside)
+        returnButton.addTarget(self, action: #selector(didTapReturnButton), for: .touchUpInside)
+    }
+
+    // MARK: - Style Helper
+    
+    private func setStyle() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    // MARK: - Layout Helper
+
+    private func setLayout() {
+        buttonStackView.addArrangedSubviews(pauseButton, returnButton)
+        
+        view.addSubviews(kickboardImage, kickboardID,
+            basicChargeTitle, hourlyChargeTitle,
+            basicCharge, hourlyCharge, rentButton, buttonStackView)
+
+        kickboardImage.snp.makeConstraints {
+            $0.width.height.equalTo(112)
+            $0.leading.equalToSuperview().inset(50)
+            $0.top.equalToSuperview().offset(38)
+        }
+
+        kickboardID.snp.makeConstraints {
+            $0.top.equalTo(kickboardImage)
+            $0.leading.equalTo(kickboardImage.snp.trailing).offset(17)
+        }
+
+        basicChargeTitle.snp.makeConstraints {
+            $0.top.equalTo(kickboardID.snp.bottom).offset(14)
+            $0.leading.equalTo(kickboardID.snp.leading)
+        }
+
+        basicCharge.snp.makeConstraints {
+            $0.top.equalTo(basicChargeTitle.snp.top)
+            $0.leading.equalTo(basicChargeTitle.snp.trailing).offset(10)
+        }
+
+        hourlyChargeTitle.snp.makeConstraints {
+            $0.top.equalTo(basicChargeTitle.snp.bottom).offset(10)
+            $0.leading.equalTo(kickboardID.snp.leading)
+        }
+
+        hourlyCharge.snp.makeConstraints {
+            $0.top.equalTo(hourlyChargeTitle.snp.top)
+            $0.leading.equalTo(hourlyChargeTitle.snp.trailing).offset(10)
+        }
+
+        rentButton.snp.makeConstraints {
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 333 / 402)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 45 / 874)
+
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-39)
+            $0.centerX.equalToSuperview()
+        }
+
+        buttonStackView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-39)
+        }
+        
+        pauseButton.snp.makeConstraints {
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 168 / 402)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 45 / 874)
+        }
+        
+        returnButton.snp.makeConstraints {
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 168 / 402)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 45 / 874)
+        }
+        
+    }
+    
+    // MARK: - Methods
+
+    func configure() {
+
+    }
+    
+    // MARK: - @objc Methods
+    
+    @objc private func didTapRentButton() {
+        rentButton.isHidden = true
+        buttonStackView.isHidden = false
+    }
+    
+    @objc private func didTapPauseButton() {
+        
+    }
+    
+    @objc private func didTapReturnButton() {
+        rentButton.isHidden = false
+        buttonStackView.isHidden = true
+    }
+    
+}

--- a/TeamProject/TeamProject/View/RentView/RentViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentViewController.swift
@@ -15,6 +15,7 @@ import KakaoMapsSDK
 final class RentViewController: KakaoMapViewController, CLLocationManagerDelegate {
     
     // MARK: - Properties
+    private let viewModel = RentViewModel.shared
     
     private let locationManager = CLLocationManager()
     
@@ -54,6 +55,7 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         addViews()
+        viewModel.fetchKickBoardRecords()
     }
     
     // MARK: - Layout Helper
@@ -87,6 +89,30 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
         
         // 위치 업데이트
         locationManager.startUpdatingLocation()
+    }
+    
+    private func setupBindings() {
+        viewModel.onRecordsUpdated = { [weak self] records in
+            guard self != nil else { return }
+            guard let mapView = self?.mapController?.getView("mapview") as? KakaoMap else { return }
+            guard let layer = mapView.getLabelManager().getLabelLayer(layerID: "PoiLayer") else { return }
+            for record in records {
+                let position = MapPoint(longitude: record.longitude, latitude: record.latitude)
+                let option = PoiOptions(styleID: "kickboardMarkStyleID")
+                option.clickable = true
+
+                if let poi = layer.addPoi(option: option, at: position) {
+                    poi.show()
+                }
+            }
+        }
+    }
+    
+    override func addViewSucceeded(_ viewName: String, viewInfoName: String) {
+        print("<<")
+        super.addViewSucceeded(viewName, viewInfoName: viewInfoName)
+        setupBindings()
+        viewModel.fetchKickBoardRecords()
     }
     
     // MARK: - @objc Methods

--- a/TeamProject/TeamProject/View/RentView/RentViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentViewController.swift
@@ -20,17 +20,17 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
     
     // MARK: - UI Components
 
-    private let locationButton = UIButton().then {
+    private let locationButton = UIButton().then { make in
         let img = ImageLiterals.location.resize(newWidth: 32)
-        $0.setImage(img, for: .normal)
-        $0.backgroundColor = .white
-        $0.layer.cornerRadius = 25
+        make.setImage(img, for: .normal)
+        make.backgroundColor = .white
+        make.layer.cornerRadius = 25
     }
     
-    private let samplePopUpModealButton = UIButton().then {
-        $0.setTitle("모달", for: .normal)
-        $0.backgroundColor = .white
-        $0.setTitleColor(UIColor.asset(.main), for: .normal)
+    private let samplePopUpModealButton = UIButton().then { make in
+        make.setTitle("모달", for: .normal)
+        make.backgroundColor = .white
+        make.setTitleColor(UIColor.asset(.main), for: .normal)
         
     }
     

--- a/TeamProject/TeamProject/View/RentView/RentViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentViewController.swift
@@ -27,6 +27,13 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
         $0.layer.cornerRadius = 25
     }
     
+    private let samplePopUpModealButton = UIButton().then {
+        $0.setTitle("모달", for: .normal)
+        $0.backgroundColor = .white
+        $0.setTitleColor(UIColor.asset(.main), for: .normal)
+        
+    }
+    
     // MARK: - View Life Cycle
     
     override func loadView() {
@@ -38,6 +45,9 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
         locationManager.delegate = self
         setLocationService()
         setLayout()
+        
+        locationButton.addTarget(self, action: #selector(didTapLocationButton), for: .touchUpInside)
+        samplePopUpModealButton.addTarget(self, action: #selector(didTapPingButton), for: .touchUpInside)
     }
     
     // 엔진이 준비·활성화된 직후에 지도 추가
@@ -49,13 +59,20 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
     // MARK: - Layout Helper
     
     private func setLayout() {
-        view.addSubview(locationButton)
+        view.addSubviews(locationButton, samplePopUpModealButton)
+        
         locationButton.snp.makeConstraints {
             $0.width.height.equalTo(53)
             $0.trailing.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
         }
-        locationButton.addTarget(self, action: #selector(didTapLocationButton), for: .touchUpInside)
+        
+        samplePopUpModealButton.snp.makeConstraints {
+            $0.width.height.equalTo(50)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+        
         view.bringSubviewToFront(locationButton)
     }
 
@@ -92,6 +109,18 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
         let cameraUpdate = CameraUpdate.make(target: point, mapView: mapView)
         mapView.moveCamera(cameraUpdate)
         print("지도 중심을 (\(coor.longitude), \(coor.latitude)로 이동했습니다.")
+    }
+    
+    @objc private func didTapPingButton() {
+        let vc = RentModalViewController()
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom(resolver: { _  in
+                return SizeLiterals.Screen.screenHeight * 257 / 874
+            })]
+            sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 20
+        }
+        present(vc, animated: true, completion: nil)
     }
 }
 

--- a/TeamProject/TeamProject/View/RentView/RentViewController.swift
+++ b/TeamProject/TeamProject/View/RentView/RentViewController.swift
@@ -96,6 +96,7 @@ final class RentViewController: KakaoMapViewController, CLLocationManagerDelegat
             guard self != nil else { return }
             guard let mapView = self?.mapController?.getView("mapview") as? KakaoMap else { return }
             guard let layer = mapView.getLabelManager().getLabelLayer(layerID: "PoiLayer") else { return }
+                        
             for record in records {
                 let position = MapPoint(longitude: record.longitude, latitude: record.latitude)
                 let option = PoiOptions(styleID: "kickboardMarkStyleID")

--- a/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
+++ b/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
@@ -42,4 +42,9 @@ final class KickBoardRecordViewModel {
         coreDataManager.save(record: record)
         fetchKickBoardRecords()
     }
+    
+    func deleteKickBoardRecord(_ identifier: UUID) {
+        coreDataManager.deleteRecord(with: identifier)
+        fetchKickBoardRecords()
+    }
 }

--- a/TeamProject/TeamProject/ViewModel/RentViewModel.swift
+++ b/TeamProject/TeamProject/ViewModel/RentViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  RentViewModel.swift
+//  TeamProject
+//
+//  Created by yimkeul on 4/29/25.
+//
+
+import Foundation
+
+final class RentViewModel {
+    
+    // MARK: - Singleton Instance
+    
+    static let shared = RentViewModel()
+    
+    // MARK: - Properties
+    
+    private let coreDataManager: CoreDataManager
+    
+    private(set) var records: [KickBoardRecord] = [] {
+        didSet {
+            onRecordsUpdated?(records)
+        }
+    }
+    
+    var onRecordsUpdated: (([KickBoardRecord]) -> Void)?
+    
+    // MARK: - Initializer
+    
+    init(coreDataManager: CoreDataManager = .shared) {
+        self.coreDataManager = coreDataManager
+    }
+    
+    // MARK: - Methods
+    
+    func fetchKickBoardRecords() {
+        let fetchedRecords = coreDataManager.fetchAllRecords()
+        self.records = fetchedRecords
+    }
+}


### PR DESCRIPTION
## 💭 작업 내용
- 킥보드 등록 페이지에서 킥보드 마크 클릭시 바텀시트가 나오게 구현
- 바텀시트에서 킥보드 상세정보가 표시되고 삭제 버튼이 나오게 구현
- 삭제 버튼 클릭시 해당 킥보드 데이터가 삭제되고 마크도 지도에서 사라지게 구현

## 🌤️ PR POINT

## 📸 스크린샷
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro |![ezgif-6f1fe0ca1499d7](https://github.com/user-attachments/assets/523233b2-e944-4aef-80fb-0b97151e8992)
 |

## 🌈 관련 이슈
- Resolved: #25 
