### PR TITLE
[Feat] #34  이용 내역, 등록 내역 VM 데이터 받아 연결

### DIFF
--- a/TeamProject/Model/RegistrationHistory.swift
+++ b/TeamProject/Model/RegistrationHistory.swift
@@ -23,32 +23,3 @@ struct RegistrationHistory {
         self.date = date
     }
 }
-
-// MARK: - RegistrationHistory Extensions
-
-extension RegistrationHistory {
-    // 기본 이용료 포맷팅
-    var formattedBasicFee: String {
-        return "\(basicFee.formatted())원"
-    }
-    
-    // 시간당 요금 포맷팅
-    var formattedHourlyFee: String {
-        return "\(hourlyFee.formatted())원"
-    }
-    
-    // 날짜 포맷팅 (필요한 경우)
-    var formattedDate: String {
-        return date
-    }
-    
-    // 전체 정보 요약
-    var summary: String {
-        return """
-        킥보드 ID: \(kickboardId)
-        기본 이용료: \(formattedBasicFee)
-        시간당 요금: \(formattedHourlyFee)
-        등록일: \(formattedDate)
-        """
-    }
-}

--- a/TeamProject/TeamProject/App/SceneDelegate.swift
+++ b/TeamProject/TeamProject/App/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let vc = LoginViewController()
+        _ = LoginViewController()
         
         // UserDefaults에서 로그인 상태 확인
         let isLoggedIn = UserDefaultsManager.shared.defaults.bool(forKey: UserDefaultsManager.Keys.isLoggedIn)

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
@@ -58,7 +58,7 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
     
     // 데이터 업데이트 메서드 추가
     func updateData(_ histories: [RegistrationHistory]) {
-        self.registrationHistories = histories
+        self.registrationHistories = histories.reversed()
         tableView.reloadData()
     }
     

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryView.swift
@@ -12,6 +12,10 @@ import Then
 
 final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
     
+    // MARK: - Properties
+    
+    private var registrationHistories: [RegistrationHistory] = []
+    
     // MARK: - UI Components
     
     private lazy var tableView = UITableView().then {
@@ -52,6 +56,12 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
         tableView.delegate = self
     }
     
+    // 데이터 업데이트 메서드 추가
+    func updateData(_ histories: [RegistrationHistory]) {
+        self.registrationHistories = histories
+        tableView.reloadData()
+    }
+    
     // 테이블뷰의 각 섹션의 헤더 높이를 설정 (헤더 높이 0으로 설정)
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 0
@@ -69,7 +79,7 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
     
     // numberOfSections 메서드 추가
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 3 // 섹션 3개로 설정
+        return registrationHistories.count
     }
     
     // numberOfRowsInSection 수정
@@ -81,8 +91,10 @@ final class RegistrationHistoryView: UIView, UITableViewDataSource, UITableViewD
         guard let cell = tableView.dequeueReusableCell(withIdentifier: RegistrationHistoryTableViewCell.RegistrationHistoryCellid, for: indexPath) as? RegistrationHistoryTableViewCell else {
             return UITableViewCell()
         }
-        // 실제 데이터로 구성할 때 아래와 같이 적으면 됨
+        // 실제 데이터로 구성할 때 다음과 같이 구성
         // cell.configure(with: yourDataModel)
+        let history = registrationHistories[indexPath.section]
+        cell.configure(with: history)
         
         return cell
     }

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
@@ -14,6 +14,8 @@ final class RegistrationHistoryViewController: UIViewController {
     // MARK: - Properties
     
     private var registrationHistoryView = RegistrationHistoryView()
+    private let KickBoardRecordVM = KickBoardRecordViewModel.shared
+
        
     // MARK: - View Life Cycle
     
@@ -21,6 +23,7 @@ final class RegistrationHistoryViewController: UIViewController {
         super.viewDidLoad()
         setupRegistrationHistoryView()
         setupNavigationBar()
+        setupViewModel()
     }
     
     // MARK: - Methods
@@ -32,5 +35,14 @@ final class RegistrationHistoryViewController: UIViewController {
     private func setupRegistrationHistoryView() {
         view.addSubview(registrationHistoryView)
         registrationHistoryView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+    
+    private func setupViewModel() {
+        KickBoardRecordVM.onRegistrationHistoriesUpdated = { [weak self] histories in
+            self?.registrationHistoryView.updateData(histories)
+        }
+        
+        KickBoardRecordVM.fetchKickBoardRecords()
+        KickBoardRecordVM.fetchRegistrationHistories()
     }
 }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -78,7 +78,6 @@ final class UsageHistoryTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
         setConstraints()
-        configureUI()
     }
     
     required init?(coder: NSCoder) {
@@ -131,15 +130,6 @@ final class UsageHistoryTableViewCell: UITableViewCell {
             make.trailing.equalToSuperview().offset(-20)
             make.centerY.equalToSuperview()
         }
-    }
-    
-    private func configureUI() {
-        // 테스트용 더미 데이터
-        kickboardIdLabel.text = "ABCDEF"
-        usageTimeLabel.text = "사용시간: 10:00 ~ 10:30(30분)"
-        distanceLabel.text = "이동거리: 0.5km"
-        dateLabel.text = "2025.04.30"
-        priceLabel.text = "9,999원"
     }
     
     func configure(with model: UsageHistory) {

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
@@ -12,6 +12,10 @@ import Then
 
 final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate {
     
+    // MARK: - Properties
+    // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
+    private var usageHistories: [UsageHistory] = []
+    
     // MARK: - UI Components
     
     private lazy var tableView = UITableView().then {
@@ -52,6 +56,11 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
         tableView.delegate = self
     }
     
+    func updateData(_ histories: [UsageHistory]) {
+        self.usageHistories = histories
+        tableView.reloadData()
+    }
+    
     // 테이블뷰의 각 섹션의 헤더 높이를 설정 (헤더 높이 0으로 설정)
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 0
@@ -69,7 +78,7 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
     
     // numberOfSections 메서드 추가
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 3 // 섹션 3개로 설정
+        return usageHistories.count
     }
     
     // numberOfRowsInSection 수정
@@ -83,6 +92,9 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
         }
         // 실제 데이터로 구성할 때 아래와 같이 적으면 됨
         // cell.configure(with: yourDataModel)
+        // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
+        let history = usageHistories[indexPath.section]
+        cell.configure(with: history)
         
         return cell
     }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryView.swift
@@ -57,7 +57,7 @@ final class UsageHistoryView: UIView, UITableViewDataSource, UITableViewDelegate
     }
     
     func updateData(_ histories: [UsageHistory]) {
-        self.usageHistories = histories
+        self.usageHistories = histories.reversed()
         tableView.reloadData()
     }
     

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
@@ -14,6 +14,9 @@ final class UsageHistoryViewController: UIViewController {
     // MARK: - Properties
     
     private var usageHistoryView = UsageHistoryView()
+    
+    // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
+    private let viewModel = KickBoardRecordViewModel.shared
        
     // MARK: - View Life Cycle
     
@@ -21,6 +24,9 @@ final class UsageHistoryViewController: UIViewController {
         super.viewDidLoad()
         setupNavigationBar()
         setupUsageHistoryView()
+        
+        // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
+        setupViewModel()
     }
     
     // MARK: - Methods
@@ -32,5 +38,36 @@ final class UsageHistoryViewController: UIViewController {
     private func setupUsageHistoryView() {
         view.addSubview(usageHistoryView)
         usageHistoryView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+    
+    // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
+    private func setupViewModel() {
+        viewModel.onRecordsUpdated = { [weak self] records in
+            // 레코드를 UsageHistory 형식으로 변환
+            let usageHistories = records.map { record in
+                // 현재 날짜와 시간 포맷팅
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy.MM.dd"
+                let timeFormatter = DateFormatter()
+                timeFormatter.dateFormat = "HH:mm"
+                
+                let currentDate = Date()
+                let dateString = dateFormatter.string(from: currentDate)
+                let timeString = timeFormatter.string(from: currentDate)
+                
+                return UsageHistory(
+                    kickboardId: record.kickboardIdentifier.uuidString.prefix(6).uppercased(),
+                    startTime: timeString,
+                    endTime: timeString, // 실제로는 종료 시간을 따로 저장해야 함
+                    distance: 0.5, // 실제 거리 계산 필요
+                    date: dateString,
+                    price: record.basicCharge
+                )
+            }
+            
+            self?.usageHistoryView.updateData(usageHistories)
+        }
+        
+        viewModel.fetchKickBoardRecords()
     }
 }


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 등록 내역, 이용내역(임시) 데이터 받아서 테이블뷰 셀에 연결
 - 테이블뷰 셀의 데이터 표기는 내림차순

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
이용 내역은 VM 완성되는대로 다시 수정해서 올리겠습니다. 현재 이용내역으로 뜨는 데이터들은 등록 내역 데이터를 받아왔습니다.
## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/3cbdc695-1dd3-42de-bcbd-4ad570b679a6" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #34
