### PR TITLE
[Feat] #39 기능 완성

### DIFF
--- a/TeamProject/TeamProject/CoreData/CoreDataManager.swift
+++ b/TeamProject/TeamProject/CoreData/CoreDataManager.swift
@@ -44,6 +44,7 @@ final class CoreDataManager {
         entity.basicCharge = Int32(record.basicCharge)
         entity.hourlyCharge = Int32(record.hourlyCharge)
         entity.type = record.type
+        entity.userID = record.userID
 
         saveContext()
     }
@@ -73,7 +74,8 @@ final class CoreDataManager {
                     kickboardIdentifier: entity.kickboardIdentifier,
                     basicCharge: Int(entity.basicCharge),
                     hourlyCharge: Int(entity.hourlyCharge),
-                    type: entity.type
+                    type: entity.type,
+                    userID: entity.userID
                 )
             }
         } catch {
@@ -92,12 +94,39 @@ final class CoreDataManager {
             if let target = results.first {
                 return KickBoardRecord(latitude: target.latitude, longitude: target.longitude,
                                        kickboardIdentifier: target.kickboardIdentifier,
-                                       basicCharge: Int(target.basicCharge), hourlyCharge: Int(target.hourlyCharge),type: target.type)
+                                       basicCharge: Int(target.basicCharge), hourlyCharge: Int(target.hourlyCharge),type: target.type,userID: target.userID)
             }
         } catch {
             print("Fetch error: \(error.localizedDescription)")
         }
         return nil
+    }
+    
+    func fetchRecordsForCurrentUser() -> [KickBoardRecord] {
+        guard let userID = UserManager.shared.getUser()?.id else {
+            return []
+        }
+
+        let fetchRequest: NSFetchRequest<KickBoardRecordEntity> = KickBoardRecordEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "userID == %@", userID)
+
+        do {
+            let entities = try context.fetch(fetchRequest)
+            return entities.compactMap { entity -> KickBoardRecord in
+                return KickBoardRecord(
+                    latitude: entity.latitude,
+                    longitude: entity.longitude,
+                    kickboardIdentifier: entity.kickboardIdentifier,
+                    basicCharge: Int(entity.basicCharge),
+                    hourlyCharge: Int(entity.hourlyCharge),
+                    type: entity.type,
+                    userID: entity.userID
+                )
+            }
+        } catch {
+            print("error: \(error.localizedDescription)")
+            return []
+        }
     }
 
     private func saveContext() {

--- a/TeamProject/TeamProject/CoreData/KickBoardRecordEntity+CoreDataProperties.swift
+++ b/TeamProject/TeamProject/CoreData/KickBoardRecordEntity+CoreDataProperties.swift
@@ -23,7 +23,7 @@ extension KickBoardRecordEntity {
     @NSManaged public var latitude: Double
     @NSManaged public var longitude: Double
     @NSManaged public var type: String
-
+    @NSManaged public var userID: String
 }
 
 extension KickBoardRecordEntity : Identifiable {

--- a/TeamProject/TeamProject/Entity/KickBoardRecord.swift
+++ b/TeamProject/TeamProject/Entity/KickBoardRecord.swift
@@ -14,4 +14,5 @@ struct KickBoardRecord {
     let basicCharge: Int
     let hourlyCharge: Int
     let type: String
+    let userID: String
 }

--- a/TeamProject/TeamProject/Entity/User.swift
+++ b/TeamProject/TeamProject/Entity/User.swift
@@ -1,0 +1,10 @@
+//
+//  User.swift
+//  TeamProject
+//
+//  Created by tlswo on 4/30/25.
+//
+
+struct User {
+    var id: String
+}

--- a/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -7,5 +7,6 @@
         <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="userID" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/TeamProject/TeamProject/Service/UserManager.swift
+++ b/TeamProject/TeamProject/Service/UserManager.swift
@@ -1,0 +1,24 @@
+//
+//  UserManager.swift
+//  TeamProject
+//
+//  Created by tlswo on 4/30/25.
+//
+
+class UserManager {
+    // MARK: - Singleton
+    static let shared = UserManager()
+    private init() {}
+
+    // MARK: - Properties
+    private var currentUser: User?
+
+    // MARK: - Methods
+    func save(user: User) {
+        self.currentUser = user
+    }
+
+    func getUser() -> User? {
+        return currentUser
+    }
+}

--- a/TeamProject/TeamProject/View/KickBoardRegisterView/RegisterKickboardAlertViewController.swift
+++ b/TeamProject/TeamProject/View/KickBoardRegisterView/RegisterKickboardAlertViewController.swift
@@ -205,7 +205,8 @@ class RegisterKickboardAlertViewController: UIViewController {
             kickboardIdentifier: recognitionNumber,
             basicCharge: basicCharge,
             hourlyCharge: hourlyCharge,
-            type: selectedType
+            type: selectedType,
+            userID: UserManager.shared.getUser()!.id
         ))
         
         dismiss(animated: true, completion: nil)

--- a/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
+++ b/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
@@ -67,6 +67,8 @@ final class LoginViewController: UIViewController,LoginViewContollerProtocol {
         
         switch loginVM.validateLogin(id: id, password: password) {
         case .success:
+            guard let id = loginView.getId() else { return }
+            UserManager.shared.save(user: User(id: id))
             loginVM.saveUserLoginInfo(id: id, password: password) //로그인 시 사용자 정보 저장
             loginVM.login()
             navigateToMain()
@@ -74,34 +76,6 @@ final class LoginViewController: UIViewController,LoginViewContollerProtocol {
             showAlert(message: message)
         }
     }
-    
-    // 로그인 성공 시 호출되는 메서드
-    func loginSuccess() {
-        //        guard let id = loginView.getId(),
-        //              let password = loginView.getPassword() else { return }
-        //
-        //        // UserDefaults에서 저장된 이름 가져오기
-        //        if let userName = UserDefaultsManager.shared.getUserName() {
-        //            // UserDefaults에 사용자 정보 저장
-        //            UserDefaultsManager.shared.saveUserInfo(id: id, password: password, name: userName)
-        //            UserDefaultsManager.shared.setLoginStatus(isLoggedIn: true)
-        
-        // MainVC로 이동
-        let mainVC = MainViewController()
-        let navigationController = UINavigationController(rootViewController: mainVC)
-        navigationController.modalPresentationStyle = .fullScreen
-        
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first {
-            window.rootViewController = navigationController
-            UIView.transition(with: window,
-                              duration: 0.3,
-                              options: .transitionCrossDissolve,
-                              animations: nil,
-                              completion: nil)
-        }
-    }
-    
     
     private func navigateToMain() {
         let mainVC = MainViewController()

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryViewController.swift
@@ -42,7 +42,7 @@ final class RegistrationHistoryViewController: UIViewController {
             self?.registrationHistoryView.updateData(histories)
         }
         
-        KickBoardRecordVM.fetchKickBoardRecords()
+        KickBoardRecordVM.fetchFilteredKickBoardRecords()
         KickBoardRecordVM.fetchRegistrationHistories()
     }
 }

--- a/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
+++ b/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
@@ -54,6 +54,13 @@ final class KickBoardRecordViewModel: NSObject {
         self.records = fetchedRecords
     }
     
+    func fetchFilteredKickBoardRecords() {
+        let fetchedRecords = coreDataManager.fetchRecordsForCurrentUser()
+        self.records = fetchedRecords
+        print("###########################")
+        print(self.records)
+    }
+    
     func saveKickBoardRecord(_ record: KickBoardRecord) {
         coreDataManager.save(record: record)
         fetchKickBoardRecords()


### PR DESCRIPTION
## 💭 작업 내용
- 로그인 User에 대한 Entity 생성
- 현재 사용자 정보를 저장하고 제공하는 UserManager 싱글톤으로 생성
- LoginViewController에 loginsuccess 메서드에서 로그인할때 해당 싱글톤 매니저에 로그인한 유저 id 저장
- 코어데이터에 userID 엔터티 추가, KickBoardRecord 엔터티에 userID 추가
- 코어데이터에 저장할때 userID도 저장하도록 수정
- 코어데이터에서 userID와 UserManager에서 가져온 id가 일치하는 데이터만 가져오는 메서드 생성
- KickBoardRecordViewModel에서 그 메서드 이용하는 메서드 생성
- 마이페이지에서 viewmodel에 메서드 호출해서 데이터 가져와서 사용

## 🌤️ PR POINT

## 📸 스크린샷
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | ![9seq6h](https://github.com/user-attachments/assets/432192fc-9c14-437f-800e-35cd6b69231c)|


## 🌈 관련 이슈
- Resolved: #39 
