### PR TITLE
[Feat] #45 - 유저 아이디별 이용 내역 필터

### DIFF
--- a/TeamProject/Model/UsageHistory.swift
+++ b/TeamProject/Model/UsageHistory.swift
@@ -13,5 +13,5 @@ struct UsageHistory {
     var finishTime: String?
     let startTime: String
     let useDate: String
-    
+    let userID: String
 }

--- a/TeamProject/TeamProject/CoreData/SubClass/UsageHistoryEntity+CoreDataProperties.swift
+++ b/TeamProject/TeamProject/CoreData/SubClass/UsageHistoryEntity+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension UsageHistoryEntity {
     @NSManaged public var kickboardIdentifier: UUID
     @NSManaged public var startTime: String
     @NSManaged public var useDate: String
+    @NSManaged public var userID: String
 
 }
 

--- a/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -15,5 +15,6 @@
         <attribute name="kickboardIdentifier" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="startTime" optional="YES" attributeType="String"/>
         <attribute name="useDate" optional="YES" attributeType="String"/>
+        <attribute name="userID" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
@@ -24,7 +24,7 @@ final class UsageHistoryViewController: UIViewController {
         super.viewDidLoad()
         setupNavigationBar()
         setupUsageHistoryView()
-        print(CoreDataManager.shared.fetchAllUsageHistorys())
+        print(CoreDataManager.shared.fetchRecordsForCurrentUser())
         
         // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
 //        setupViewModel()


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - CoreData - UsageHistory 수정 (userID 추가)
 - CoreDataManager에 유저 아이디별 이용 내역 필터 추가

## 🌤️ PR POINT
UsageHistoryViewController의 viewdidload 출력문으로 확인 가능합니다

## 📸 스크린샷

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #45 
