### PR TITLE
[Fix] #52 - 로그아웃 후 로그인 시 네비게이션바 중첩 문제해결

### DIFF
--- a/TeamProject/TeamProject/App/SceneDelegate.swift
+++ b/TeamProject/TeamProject/App/SceneDelegate.swift
@@ -27,8 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 
                 // 로그인된 상태면 MainVC로 이동
                 let mainVC = MainViewController()
-                let navigationController = UINavigationController(rootViewController: mainVC)
-                window?.rootViewController = navigationController
+                window?.rootViewController = mainVC
             }
         } else {
             // 로그인되지 않은 상태면 LoginVC로 이동

--- a/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
+++ b/TeamProject/TeamProject/View/LoginView/LoginViewController.swift
@@ -94,10 +94,17 @@ final class LoginViewController: UIViewController,LoginViewContollerProtocol {
         }
     }
     
+    // 로그인 후 완전히 새로운 시작점을 만들어 네비게이션 컨트롤러 중첩 문제를 해결
     private func navigateToMain() {
         let mainVC = MainViewController()
-        // 네비게이션 스택을 초기화하고 메인화면을 루트로 설정
-        navigationController?.setViewControllers([mainVC], animated: true)
+        if let window = view.window {
+            window.rootViewController = mainVC
+            UIView.transition(with: window,
+                              duration: 0.3,
+                              options: .transitionCrossDissolve,
+                              animations: nil,
+                              completion: nil)
+        }
     }
     
     func signUpButtonTapped() {

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -113,14 +113,6 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
         }
     }
     
-    private func configureUI() {
-        // 테스트용 더미 데이터
-        kickboardIdLabel.text = "ABCDEF"
-        basicFeeLabel.text = "기본 이용료: 1,000원"
-        hourlyFeeLabel.text = "시간당 요금: 200원"
-        dateLabel.text = "2025.04.30"
-    }
-    
     func configure(with model: RegistrationHistory) {
         kickboardIdLabel.text = model.kickboardId
         basicFeeLabel.text = "기본 이용료: \(model.basicFee)원"

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -62,7 +62,6 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
         setConstraints()
-        configureUI()
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 마이페이지, 이용 내역, 등록 내역 화면에서 재로그인, 로그인 화면에서 접속 시 네비게이션이 중첩되는 현상 발생

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
맨 처음 로그인, 로그인 상태에서 시뮬레이션 재실행, 로그아웃 후 로그인 상태에서 네비게이션 중첩 되는 부분 모두 수정했습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/1e5d6cd2-dba9-4f8c-a939-6e904c8322bc" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #52
