### PR TITLE
[Fix] - 이용내역 데이터 연결 재작업 및 UI 수정

### DIFF
--- a/TeamProject/Model/UsageHistory.swift
+++ b/TeamProject/Model/UsageHistory.swift
@@ -15,4 +15,5 @@ struct UsageHistory {
     let useDate: String
     let userID: String
     let distance: Double
+    let type: String
 }

--- a/TeamProject/Model/UsageHistory.swift
+++ b/TeamProject/Model/UsageHistory.swift
@@ -14,4 +14,5 @@ struct UsageHistory {
     let startTime: String
     let useDate: String
     let userID: String
+    let distance: Double
 }

--- a/TeamProject/TeamProject/CoreData/CoreDataManager.swift
+++ b/TeamProject/TeamProject/CoreData/CoreDataManager.swift
@@ -207,6 +207,9 @@ final class CoreDataManager {
         do {
             let entities = try context.fetch(request)
             return entities.compactMap { entity -> UsageHistory in
+                //이미지 사용을 위한 킥보드 타입 정보 가져오기
+                let kickboardRecord = fetchRecord(with: entity.kickboardIdentifier)
+
                 return UsageHistory(
                     kickboardIdentifier: entity.kickboardIdentifier,
                     charge: Int(entity.charge),
@@ -214,7 +217,8 @@ final class CoreDataManager {
                     startTime: entity.startTime,
                     useDate: entity.useDate,
                     userID: entity.userID,
-                    distance: entity.distance
+                    distance: entity.distance,
+                    type: kickboardRecord?.type ?? "A"
                 )
             }
         } catch {
@@ -234,6 +238,9 @@ final class CoreDataManager {
         do {
             let entities = try context.fetch(fetchRequest)
             return entities.compactMap { entity -> UsageHistory in
+                //이미지 사용을 위한 킥보드 타입 정보 가져오기
+                let kickboardRecord = fetchRecord(with: entity.kickboardIdentifier)
+
                 return UsageHistory(
                     kickboardIdentifier: entity.kickboardIdentifier,
                     charge: Int(entity.charge),
@@ -241,7 +248,8 @@ final class CoreDataManager {
                     startTime: entity.startTime,
                     useDate: entity.useDate,
                     userID: entity.userID,
-                    distance: entity.distance
+                    distance: entity.distance,
+                    type: kickboardRecord?.type ?? "A"
                 )
             }
         } catch {

--- a/TeamProject/TeamProject/CoreData/CoreDataManager.swift
+++ b/TeamProject/TeamProject/CoreData/CoreDataManager.swift
@@ -82,7 +82,7 @@ final class CoreDataManager {
         fetchRequest.fetchLimit = 1
         
         
-        guard let kickboardRecord = fetchRecord(with: identifier) else { return nil }
+        guard fetchRecord(with: identifier) != nil else { return nil }
         
         do {
             if let entity = try context.fetch(fetchRequest).first {

--- a/TeamProject/TeamProject/CoreData/SubClass/UsageHistoryEntity+CoreDataProperties.swift
+++ b/TeamProject/TeamProject/CoreData/SubClass/UsageHistoryEntity+CoreDataProperties.swift
@@ -22,6 +22,7 @@ extension UsageHistoryEntity {
     @NSManaged public var startTime: String
     @NSManaged public var useDate: String
     @NSManaged public var userID: String
+    @NSManaged public var distance: Double
 
 }
 

--- a/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/TeamProject/TeamProject/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="KickBoardRecordEntity" representedClassName="KickBoardRecordEntity" syncable="YES">
         <attribute name="basicCharge" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="hourlyCharge" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -11,6 +11,7 @@
     </entity>
     <entity name="UsageHistoryEntity" representedClassName="UsageHistoryEntity" syncable="YES">
         <attribute name="charge" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="distance" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="finishTime" optional="YES" attributeType="String"/>
         <attribute name="kickboardIdentifier" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="startTime" optional="YES" attributeType="String"/>

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -97,7 +97,7 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
         }
         
         kickboardImageView.snp.makeConstraints { make in
-            make.width.height.equalTo(40)
+            make.width.height.equalTo(50)
         }
         
         containerStackView.snp.makeConstraints { make in

--- a/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/RegistrationHistory/RegistrationHistoryComponents/RegistrationHistoryTableViewCell.swift
@@ -20,12 +20,12 @@ final class RegistrationHistoryTableViewCell: UITableViewCell {
     
     private let containerStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.spacing = 15
+        $0.spacing = 10
         $0.alignment = .center
     }
     
     private let kickboardImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
     }
     

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -132,7 +132,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     
     func configure(with model: UsageHistory) {
         
-        kickboardIdLabel.text = model.kickboardIdentifier.uuidString.prefix(10).uppercased()
+        kickboardIdLabel.text = model.kickboardIdentifier.uuidString.prefix(8).uppercased()
         
         if model.finishTime != nil {
             let distance = Date.minutesBetween(model.startTime, and: model.finishTime!)

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -134,7 +134,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
         
         kickboardIdLabel.text = model.kickboardIdentifier.uuidString.prefix(10).uppercased()
         
-        if let finishTime = model.finishTime {
+        if model.finishTime != nil {
             let distance = Date.minutesBetween(model.startTime, and: model.finishTime!)
             usageTimeLabel.text = "사용시간: \(model.startTime) ~ \(model.finishTime!) (\(distance)분)"
         } else {

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -25,7 +25,6 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     }
     
     private let kickboardImageView = UIImageView().then {
-        $0.image = ImageLiterals.kickboard
         $0.contentMode = .scaleAspectFit
         $0.clipsToBounds = true
     }
@@ -133,15 +132,18 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     
     func configure(with model: UsageHistory) {
         
-        kickboardIdLabel.text = model.kickboardIdentifier.uuidString
-        if model.finishTime != nil {
-            let diff = Date.minutesBetween(model.startTime, and: model.finishTime!)
-            usageTimeLabel.text = "사용시간: \(model.startTime) ~ \(model.finishTime!) (\(diff)분)"
+        kickboardIdLabel.text = model.kickboardIdentifier.uuidString.prefix(10).uppercased()
+        
+        if let finishTime = model.finishTime {
+            let distance = Date.minutesBetween(model.startTime, and: model.finishTime!)
+            usageTimeLabel.text = "사용시간: \(model.startTime) ~ \(model.finishTime!) (\(distance)분)"
         } else {
-            usageTimeLabel.text = "사용시간: 이용중"
+            usageTimeLabel.text = "사용시간: \(model.startTime) ~ (이용중)"
         }
-//        distanceLabel.text = "이동거리: \(model.distance)km"
+        
+        distanceLabel.text = "이동거리: \(String(format: "%.2f", model.distance))km"
         dateLabel.text = model.useDate
         priceLabel.text = "\(model.charge.formattedPrice)원"
+        //kickboardImageView.image = UIImage(named: "kickboard_\(model.type)")
     }
 }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -25,7 +25,7 @@ final class UsageHistoryTableViewCell: UITableViewCell {
     }
     
     private let kickboardImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
     }
     

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryComponents/UsageHistoryTableViewCell.swift
@@ -144,6 +144,6 @@ final class UsageHistoryTableViewCell: UITableViewCell {
         distanceLabel.text = "이동거리: \(String(format: "%.2f", model.distance))km"
         dateLabel.text = model.useDate
         priceLabel.text = "\(model.charge.formattedPrice)원"
-        //kickboardImageView.image = UIImage(named: "kickboard_\(model.type)")
+        kickboardImageView.image = UIImage(named: "kickboard_\(model.type)")
     }
 }

--- a/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
+++ b/TeamProject/TeamProject/View/UsageHistory/UsageHistoryViewController.swift
@@ -24,10 +24,9 @@ final class UsageHistoryViewController: UIViewController {
         super.viewDidLoad()
         setupNavigationBar()
         setupUsageHistoryView()
+        setupViewModel()
+
         print(CoreDataManager.shared.fetchUsageHistorysForCurrentUser())
-        
-        // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
-//        setupViewModel()
     }
     
     // MARK: - Methods
@@ -42,33 +41,8 @@ final class UsageHistoryViewController: UIViewController {
     }
     
     // TODO: 현재는 이용 내역 VM이 없어서 등록 내역을 가져와서 출력(추후 해당 내용 수정)
-//    private func setupViewModel() {
-//        viewModel.onRecordsUpdated = { [weak self] records in
-//            // 레코드를 UsageHistory 형식으로 변환
-//            let usageHistories = records.map { record in
-//                // 현재 날짜와 시간 포맷팅
-//                let dateFormatter = DateFormatter()
-//                dateFormatter.dateFormat = "yyyy.MM.dd"
-//                let timeFormatter = DateFormatter()
-//                timeFormatter.dateFormat = "HH:mm"
-//                
-//                let currentDate = Date()
-//                let dateString = dateFormatter.string(from: currentDate)
-//                let timeString = timeFormatter.string(from: currentDate)
-//                
-//                return UsageHistory(
-//                    kickboardId: record.kickboardIdentifier.uuidString.prefix(6).uppercased(),
-//                    startTime: timeString,
-//                    endTime: timeString, // 실제로는 종료 시간을 따로 저장해야 함
-//                    distance: 0.5, // 실제 거리 계산 필요
-//                    date: dateString,
-//                    price: record.basicCharge
-//                )
-//            }
-//            
-//            self?.usageHistoryView.updateData(usageHistories)
-//        }
-//        
-//        viewModel.fetchKickBoardRecords()
-//    }
+    private func setupViewModel() {
+        let histories = CoreDataManager.shared.fetchUsageHistorysForCurrentUser()
+        usageHistoryView.updateData(histories)
+    }
 }

--- a/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
+++ b/TeamProject/TeamProject/ViewModel/KickBoardRecordViewModel.swift
@@ -84,7 +84,7 @@ final class KickBoardRecordViewModel: NSObject {
             dateFormatter.dateFormat = "yyyy.MM.dd"
             
             return RegistrationHistory(
-                kickboardId: record.kickboardIdentifier.uuidString.prefix(6).uppercased(),
+                kickboardId: record.kickboardIdentifier.uuidString.prefix(8).uppercased(),
                 basicFee: record.basicCharge,
                 hourlyFee: record.hourlyCharge,
                 date: dateFormatter.string(from: Date()),

--- a/TeamProject/TeamProject/ViewModel/RentViewModel.swift
+++ b/TeamProject/TeamProject/ViewModel/RentViewModel.swift
@@ -70,7 +70,7 @@ final class RentViewModel: NSObject {
         }
     }
     
-    private func haversineDistance(from start: Location, to end: Location) -> Double {
+    func haversineDistance(from start: Location, to end: Location) -> Double {
         let earthRadius = 6_371.0
         
         let startLatRad = start.latitude * .pi / 180


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 코어데이터에 이동거리 저장  변수 추가 후 CoreDataManager에서 데이터 받아 UsageHistoryTableView Cell에 출렫괴도록 수정
 - 이동거리는 소수점 두자리(.2f)로 표기되도록 수정
 - CoreDataManager에서 사용하지 않아 경고 메시지가 뜨는 kikckboardRecord 변수 삭제
 - 이용 내역에 대여한 킥보드 이미지가 뜨도록 타입 추가 후 수정
 - 이용 내역, 등록 내역에 아이디가 일치하도록 preifx(8)로 동일하게 수정, 이미지 크기가 다른 부분 동일하게 보이도록 수정

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
작업 모두 끝났습니다. 리팩토링 진행하면 될 것 같습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/a2d1a59b-0e6d-4fe7-b0ad-468e69cefbc4" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #55
